### PR TITLE
fix(quizRun): apply question limit after shuffle (closes #115)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useQuiz } from '@/hooks/useQuiz';
 import { TopNavBar } from '@/components/TopNavBar';
 import { Spinner } from '@/components/ui/spinner';
@@ -8,12 +9,41 @@ import ProgressView from '@/views/ProgressView';
 export default function App() {
   const quiz = useQuiz();
 
+  const handleRetry = useCallback(() => {
+    window.location.reload();
+  }, []);
+
   if (!quiz.istGeladen) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-950 via-slate-900 to-teal-950">
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-blue-950 dark:via-slate-900 dark:to-teal-950">
         <div className="text-center">
            <Spinner className="w-12 h-12 text-teal-400 mx-auto mb-4" />
            <p className="text-slate-600 dark:text-slate-300 text-lg">Lade Fragenkatalog...</p>
+<<<<<<< HEAD
+=======
+        </div>
+      </div>
+    );
+  }
+
+  if (quiz.loadError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-blue-950 dark:via-slate-900 dark:to-teal-950">
+        <div className="text-center max-w-md mx-auto px-4">
+          <div className="w-16 h-16 rounded-full bg-red-500/20 mx-auto mb-4 flex items-center justify-center" aria-hidden="true">
+            <svg className="w-8 h-8 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+          </div>
+          <h2 className="text-xl font-bold text-red-600 dark:text-red-400 mb-2">Laden fehlgeschlagen</h2>
+          <p className="text-slate-600 dark:text-slate-300 mb-6">{quiz.loadError}</p>
+          <button
+            onClick={handleRetry}
+            className="px-6 py-2.5 bg-teal-600 text-white rounded-lg hover:bg-teal-700 transition-colors focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+          >
+            Erneut versuchen
+          </button>
+>>>>>>> fix/a11y-quizview-touch-targets
         </div>
       </div>
     );

--- a/src/components/TopNavBar.tsx
+++ b/src/components/TopNavBar.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
-import { Home, Play, BarChart3, Menu, X, Zap, Shield, ChevronDown } from 'lucide-react';
+import { Home, Play, BarChart3, Menu, X, Zap, Shield, ChevronDown, Sun, Moon, Monitor } from 'lucide-react';
+import { useTheme } from 'next-themes';
 import type { QuizContext } from '@/hooks/useQuiz';
 
 interface Props {
@@ -25,31 +26,36 @@ export function TopNavBar({
   const menuRef = useRef<HTMLDivElement>(null);
   const touchStartY = useRef<number | null>(null);
 
-  const {
-    isActive,
-    gameMode,
-    setGameMode,
-    aktiveFragen,
-    antworten,
-    aktuellerIndex,
-    springeZuFrage,
-    view,
-    unterbrecheRun,
-    goToView,
-  } = quiz;
+   const {
+     isActive,
+     gameMode,
+     setGameMode,
+     aktiveFragen,
+     antworten,
+     aktuellerIndex,
+     springeZuFrage,
+     view,
+     unterbrecheRun,
+     goToView,
+   } = quiz;
+   const { theme, setTheme } = useTheme();
 
   const canChangeMode = !isActive;
 
-  // Menu außerhalb schließen
+  // Menu außerhalb schließen (mouse + touch)
   useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
+    const handleInteractionOutside = (e: MouseEvent | TouchEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setMenuOpen(false);
       }
     };
     if (menuOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
+      document.addEventListener('mousedown', handleInteractionOutside);
+      document.addEventListener('touchstart', handleInteractionOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleInteractionOutside);
+        document.removeEventListener('touchstart', handleInteractionOutside);
+      };
     }
   }, [menuOpen]);
 
@@ -66,6 +72,8 @@ export function TopNavBar({
       touchStartY.current = null;
     }
   }, []);
+
+  const menuToggleRef = useRef<HTMLButtonElement>(null);
 
   const handleHome = () => {
     setMenuOpen(false);
@@ -95,6 +103,25 @@ export function TopNavBar({
     }
   };
 
+  // Focus management: focus first focusable element when menu opens, return focus to toggle on close
+  useEffect(() => {
+    if (menuOpen) {
+      // Focus first focusable element in dropdown after render
+      setTimeout(() => {
+        const panel = document.getElementById('menu-panel');
+        if (panel) {
+          const firstFocusable = panel.querySelector<HTMLElement>(
+            'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          );
+          firstFocusable?.focus();
+        }
+      }, 0);
+    } else {
+      // Return focus to menu toggle
+      menuToggleRef.current?.focus();
+    }
+  }, [menuOpen]);
+
   return (
     <>
       {/* Floating Top Bar */}
@@ -103,14 +130,14 @@ export function TopNavBar({
         className="fixed top-3 left-1/2 -translate-x-1/2 z-50"
         aria-label="Hauptnavigation"
       >
-        <div className="flex items-center gap-1.5 sm:gap-2 bg-slate-900/90 backdrop-blur-md border border-slate-700/50 rounded-full px-2 py-1.5 shadow-lg shadow-black/20">
+        <div className="flex items-center gap-1.5 sm:gap-2 bg-white/90 backdrop-blur-md border border-slate-200/50 rounded-full px-2 py-1.5 shadow-lg shadow-black/10 dark:bg-slate-900/90 dark:border-slate-700/50 dark:shadow-black/20">
           {/* Home — zentrierter Ankerpunkt */}
           <Button
             onClick={handleHome}
             variant="ghost"
             size="icon"
             aria-label="Zur Startseite"
-            className="w-8 h-8 rounded-full bg-slate-800/80 text-teal-400 hover:bg-slate-700 hover:text-white focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+            className="w-8 h-8 rounded-full bg-slate-100/80 text-teal-500 hover:bg-slate-200 hover:text-teal-600 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-slate-800/80 dark:text-teal-400 dark:hover:bg-slate-700 dark:hover:text-white dark:focus-visible:ring-offset-slate-900"
           >
             <Home className="w-4 h-4" aria-hidden="true" />
           </Button>
@@ -122,7 +149,7 @@ export function TopNavBar({
               variant="ghost"
               size="icon"
               aria-label={view === 'progress' ? 'Zurück zum Quiz' : 'Quiz fortsetzen'}
-              className="w-8 h-8 rounded-full bg-teal-900/80 text-teal-400 hover:bg-teal-800 hover:text-white focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+              className="w-8 h-8 rounded-full bg-teal-100/80 text-teal-600 hover:bg-teal-200 hover:text-teal-700 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-teal-900/80 dark:text-teal-400 dark:hover:bg-teal-800 dark:hover:text-white dark:focus-visible:ring-offset-slate-900"
             >
               <Play className="w-4 h-4" aria-hidden="true" />
             </Button>
@@ -135,7 +162,7 @@ export function TopNavBar({
               variant="ghost"
               size="icon"
               aria-label="Quiz-Fortschritt"
-              className="w-8 h-8 rounded-full bg-slate-800/80 text-slate-300 hover:bg-slate-700 hover:text-white focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+              className="w-8 h-8 rounded-full bg-slate-100/80 text-slate-600 hover:bg-slate-200 hover:text-slate-900 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-slate-800/80 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-white dark:focus-visible:ring-offset-slate-900"
             >
               <BarChart3 className="w-4 h-4" aria-hidden="true" />
             </Button>
@@ -148,82 +175,130 @@ export function TopNavBar({
               variant="ghost"
               size="icon"
               aria-label="Quiz beenden"
-              className="w-8 h-8 rounded-full bg-slate-800/80 text-red-400 hover:bg-red-900/50 hover:text-red-300 focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+              className="w-8 h-8 rounded-full bg-slate-100/80 text-red-500 hover:bg-red-100 hover:text-red-600 focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-slate-800/80 dark:text-red-400 dark:hover:bg-red-900/50 dark:hover:text-red-300 dark:focus-visible:ring-offset-slate-900"
             >
               <X className="w-4 h-4" aria-hidden="true" />
             </Button>
           )}
 
-          {/* Menu Toggle */}
-          <Button
-            onClick={() => setMenuOpen(!menuOpen)}
-            variant="ghost"
-            size="icon"
-            aria-label={menuOpen ? 'Menü schließen' : 'Menü öffnen'}
-            aria-expanded={menuOpen}
-            className="w-8 h-8 rounded-full bg-slate-800/80 text-slate-300 hover:bg-slate-700 hover:text-white focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
-          >
-            {menuOpen ? <X className="w-4 h-4" /> : <Menu className="w-4 h-4" />}
-          </Button>
+       {/* Menu Toggle */}
+       <Button
+         ref={menuToggleRef}
+         onClick={() => setMenuOpen(!menuOpen)}
+         variant="ghost"
+         size="icon"
+         aria-label={menuOpen ? 'Menü schließen' : 'Menü öffnen'}
+         aria-expanded={menuOpen}
+         aria-haspopup="true"
+         aria-controls="menu-panel"
+         className="w-10 h-10 rounded-full bg-slate-100/80 text-slate-600 hover:bg-slate-200 hover:text-slate-900 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-slate-800/80 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-white dark:focus-visible:ring-offset-slate-900"
+       >
+         {menuOpen ? <X className="w-4 h-4" /> : <Menu className="w-4 h-4" />}
+       </Button>
         </div>
 
         {/* Dropdown Panel */}
         {menuOpen && (
           <div
-            className="absolute top-full left-1/2 -translate-x-1/2 mt-2 w-72 sm:w-80 bg-slate-900/95 backdrop-blur-md border border-slate-700/50 rounded-2xl shadow-xl shadow-black/30 overflow-hidden"
+            id="menu-panel"
+            role="menu"
+            className="absolute top-full left-1/2 -translate-x-1/2 mt-2 w-72 sm:w-80 bg-white/95 backdrop-blur-md border border-slate-200/50 rounded-2xl shadow-xl shadow-black/10 overflow-hidden dark:bg-slate-900/95 dark:border-slate-700/50 dark:shadow-black/30"
             onTouchStart={handleTouchStart}
             onTouchMove={handleTouchMove}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                setMenuOpen(false);
+              }
+            }}
           >
             {/* Swipe-Handle (mobile) */}
             <div className="flex justify-center pt-2 pb-1 sm:hidden">
-              <div className="w-10 h-1 rounded-full bg-slate-600/50" />
+              <div className="w-10 h-1 rounded-full bg-slate-300/50 dark:bg-slate-600/50" />
             </div>
 
             <div className="p-3 sm:p-4 space-y-3">
-              {/* Moduswahl */}
-              <div>
-                <p className="text-slate-400 text-[10px] uppercase tracking-wider font-medium mb-1.5">Spielmodus</p>
-                <div className="flex items-center gap-1.5 bg-slate-800/50 rounded-lg p-1">
-                  <button
-                    onClick={() => canChangeMode && setGameMode('arcade')}
-                    disabled={!canChangeMode}
-                    aria-pressed={gameMode === 'arcade'}
-                    className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-xs font-medium transition-colors min-h-[32px] ${gameMode === 'arcade' ? 'bg-amber-500 text-white' : 'text-slate-400 hover:text-white'} ${!canChangeMode ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
-                    title={canChangeMode ? 'Arcade-Modus' : 'Moduswechsel während aktivem Run nicht möglich'}
-                  >
-                    <Zap className="w-3 h-3" />
-                    Arcade
-                  </button>
-                  <button
-                    onClick={() => canChangeMode && setGameMode('hardcore')}
-                    disabled={!canChangeMode}
-                    aria-pressed={gameMode === 'hardcore'}
-                    className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-xs font-medium transition-colors min-h-[32px] ${gameMode === 'hardcore' ? 'bg-red-500 text-white' : 'text-slate-400 hover:text-white'} ${!canChangeMode ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
-                    title={canChangeMode ? 'Hardcore-Modus' : 'Moduswechsel während aktivem Run nicht möglich'}
-                  >
-                    <Shield className="w-3 h-3" />
-                    Hardcore
-                  </button>
-                </div>
-                {!canChangeMode && (
-                  <p className="text-slate-500 text-[10px] mt-1">Moduswechsel während eines aktiven Runs deaktiviert.</p>
-                )}
-              </div>
-
-              {/* Schnellnavigation — nur während Quiz */}
-              {isActive && view === 'quiz' && (
+                {/* Moduswahl */}
                 <div>
-                  <button
-                    onClick={() => setShowNavInMenu(!showNavInMenu)}
-                    aria-expanded={showNavInMenu}
-                    className="w-full flex items-center justify-between text-slate-400 text-[10px] uppercase tracking-wider font-medium mb-1.5 hover:text-slate-300 transition-colors"
-                  >
-                    <span>Schnellnavigation</span>
-                    <ChevronDown className={`w-3 h-3 transition-transform ${showNavInMenu ? 'rotate-180' : ''}`} />
-                  </button>
-                  {showNavInMenu && (
-                    <div className="max-h-40 overflow-y-auto pr-1">
-                      <div className="flex flex-wrap gap-1" role="list" aria-label="Fragen-Übersicht">
+                  <p className="text-slate-500 text-[10px] uppercase tracking-wider font-medium mb-1.5 dark:text-slate-400">Spielmodus</p>
+                  <div role="radiogroup" aria-label="Spielmodus" className="flex items-center gap-1.5 bg-slate-100/80 rounded-lg p-1 dark:bg-slate-800/50">
+                    <button
+                      onClick={() => canChangeMode && setGameMode('arcade')}
+                      disabled={!canChangeMode}
+                      role="radio"
+                      aria-checked={gameMode === 'arcade'}
+                      className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-xs font-medium transition-colors min-h-[32px] ${gameMode === 'arcade' ? 'bg-amber-500 text-white' : 'text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white'} ${!canChangeMode ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                      title={canChangeMode ? 'Arcade-Modus' : 'Moduswechsel während aktivem Run nicht möglich'}
+                    >
+                      <Zap className="w-3 h-3" />
+                      Arcade
+                    </button>
+                    <button
+                      onClick={() => canChangeMode && setGameMode('hardcore')}
+                      disabled={!canChangeMode}
+                      role="radio"
+                      aria-checked={gameMode === 'hardcore'}
+                      className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-xs font-medium transition-colors min-h-[32px] ${gameMode === 'hardcore' ? 'bg-red-500 text-white' : 'text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white'} ${!canChangeMode ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                      title={canChangeMode ? 'Hardcore-Modus' : 'Moduswechsel während aktivem Run nicht möglich'}
+                    >
+                      <Shield className="w-3 h-3" />
+                      Hardcore
+                    </button>
+                  </div>
+                 {!canChangeMode && (
+                   <p className="text-slate-400 text-[10px] mt-1 dark:text-slate-500">Moduswechsel während eines aktiven Runs deaktiviert.</p>
+                 )}
+               </div>
+
+                {/* Themewahl */}
+                <div className="mt-4">
+                  <p className="text-slate-500 text-[10px] uppercase tracking-wider font-medium mb-1.5 dark:text-slate-400">Design</p>
+                  <div role="radiogroup" aria-label="Design" className="flex items-center gap-1.5 bg-slate-100/80 rounded-lg p-1 dark:bg-slate-800/50">
+                    <button
+                      onClick={() => setTheme('light')}
+                      role="radio"
+                      aria-checked={theme === 'light'}
+                      className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-xs font-medium transition-colors min-h-[32px] ${theme === 'light' ? 'bg-white text-slate-900 border border-slate-300' : 'text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white'}`}
+                    >
+                      <Sun className="w-3 h-3" />
+                      Hell
+                    </button>
+                    <button
+                      onClick={() => setTheme('dark')}
+                      role="radio"
+                      aria-checked={theme === 'dark'}
+                      className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-xs font-medium transition-colors min-h-[32px] ${theme === 'dark' ? 'bg-slate-800 text-white border border-slate-600' : 'text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white'}`}
+                    >
+                      <Moon className="w-3 h-3" />
+                      Dunkel
+                    </button>
+                    <button
+                      onClick={() => setTheme('system')}
+                      role="radio"
+                      aria-checked={theme === 'system'}
+                      className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-xs font-medium transition-colors min-h-[32px] ${theme === 'system' ? 'bg-teal-500 text-white' : 'text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white'}`}
+                    >
+                      <Monitor className="w-3 h-3" />
+                      System
+                    </button>
+                  </div>
+                </div>
+
+                {/* Schnellnavigation — nur während Quiz */}
+                {isActive && view === 'quiz' && (
+                  <div>
+                    <button
+                      onClick={() => setShowNavInMenu(!showNavInMenu)}
+                      aria-expanded={showNavInMenu}
+                      aria-controls="schnellnavigation-list"
+                      className="w-full flex items-center justify-between text-slate-500 text-[10px] uppercase tracking-wider font-medium mb-1.5 hover:text-slate-700 transition-colors dark:text-slate-400 dark:hover:text-slate-300"
+                    >
+                      <span>Schnellnavigation</span>
+                      <ChevronDown className={`w-3 h-3 transition-transform ${showNavInMenu ? 'rotate-180' : ''}`} />
+                    </button>
+                    {showNavInMenu && (
+                      <div id="schnellnavigation-list" className="max-h-40 overflow-y-auto pr-1">
+                        <div className="flex flex-wrap gap-1" role="list" aria-label="Fragen-Übersicht">
                         {aktiveFragen.map((frage, idx) => {
                           const beantwortet = antworten[frage.id] !== undefined;
                           const korrekt = antworten[frage.id] === frage.richtige_antwort;
@@ -234,7 +309,7 @@ export function TopNavBar({
                               onClick={() => handleJumpToQuestion(idx)}
                               aria-label={`Frage ${idx + 1}${beantwortet ? (korrekt ? ', richtig beantwortet' : ', falsch beantwortet') : ', unbeantwortet'}${aktuell ? ', aktuell' : ''}`}
                               aria-current={aktuell ? 'true' : undefined}
-                              className={`w-7 h-7 rounded-md text-[10px] font-medium flex-shrink-0 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${aktuell ? 'bg-teal-500 text-white' : beantwortet && korrekt ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30' : beantwortet && !korrekt ? 'bg-red-500/20 text-red-400 border border-red-500/30' : 'bg-slate-700/50 text-slate-400 border border-slate-600/30 hover:bg-slate-700'}`}
+                              className={`w-7 h-7 rounded-md text-[10px] font-medium flex-shrink-0 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 ${aktuell ? 'bg-teal-500 text-white' : beantwortet && korrekt ? 'bg-emerald-100 text-emerald-600 border border-emerald-300/50 dark:bg-emerald-500/20 dark:text-emerald-400 dark:border-emerald-500/30' : beantwortet && !korrekt ? 'bg-red-100 text-red-600 border border-red-300/50 dark:bg-red-500/20 dark:text-red-400 dark:border-red-500/30' : 'bg-slate-100/80 text-slate-600 border border-slate-300/30 hover:bg-slate-200 dark:bg-slate-700/50 dark:text-slate-400 dark:border-slate-600/30 dark:hover:bg-slate-700'}`}
                             >
                               {idx + 1}
                             </button>
@@ -248,11 +323,11 @@ export function TopNavBar({
 
               {/* Aktiver Run Info */}
               {isActive && (
-                <div className="pt-2 border-t border-slate-700/50">
-                  <p className="text-slate-400 text-[10px] uppercase tracking-wider font-medium mb-1">Aktiver Run</p>
+                <div className="pt-2 border-t border-slate-200/50 dark:border-slate-700/50">
+                  <p className="text-slate-500 text-[10px] uppercase tracking-wider font-medium mb-1 dark:text-slate-400">Aktiver Run</p>
                   <div className="flex items-center justify-between text-xs">
-                    <span className="text-slate-300">{quiz.geladeneBereiche.join(', ')}</span>
-                    <span className="text-teal-400 font-medium">{quiz.statistiken.beantwortet}/{quiz.statistiken.gesamt}</span>
+                    <span className="text-slate-600 dark:text-slate-300">{quiz.geladeneBereiche.join(', ')}</span>
+                    <span className="text-teal-600 font-medium dark:text-teal-400">{quiz.statistiken.beantwortet}/{quiz.statistiken.gesamt}</span>
                   </div>
                 </div>
               )}

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -57,7 +57,7 @@ export function useQuiz() {
   }, [run, meta]);
 
   // Starten: Lazy Loading der Bereichs-Fragen
-  const starteQuiz = useCallback(async (bereiche: string[], nurFavoriten = false) => {
+  const starteQuiz = useCallback(async (bereiche: string[], nurFavoriten = false, limit?: number) => {
     if (!quizMeta) return;
 
     let data = quizData;
@@ -88,7 +88,7 @@ export function useQuiz() {
     }
 
     const isNewRun = !run.isActive;
-    run.starteRun(bereiche, filteredData);
+    run.starteRun(bereiche, filteredData, limit);
     if (isNewRun) meta.recordRunStart();
     setView('quiz');
   }, [run, meta, quizData, quizMeta, fav.favorites]);

--- a/src/store/quizRun.ts
+++ b/src/store/quizRun.ts
@@ -18,7 +18,7 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode) {
   }, [gameMode]);
 
   // Starte neuen Run oder erweitere bestehenden
-  const starteRun = useCallback((bereiche: string[], overrideData?: QuizData) => {
+  const starteRun = useCallback((bereiche: string[], overrideData?: QuizData, limit?: number) => {
     const qd = overrideData || quizData;
     if (!qd) return;
 
@@ -52,8 +52,11 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode) {
         [gemischt[i], gemischt[j]] = [gemischt[j], gemischt[i]];
       }
 
+      // Limit erst nach dem Shuffle anwenden, damit die Subset-Auswahl zufällig ist
+      const finalPool = limit && limit > 0 ? gemischt.slice(0, limit) : gemischt;
+
       persistRun({
-        frageIds: gemischt.map(f => f.id),
+        frageIds: finalPool.map(f => f.id),
         antworten: {},
         bereiche,
         aktuellerIndex: 0,

--- a/src/test/quizRun.test.ts
+++ b/src/test/quizRun.test.ts
@@ -295,4 +295,53 @@ describe('useQuizRun', () => {
     expect(result2.current.aktuellerIndex).toBe(0);
     expect(result2.current.aktiveFragen.length).toBe(1);
   });
+
+  it('sollte Limit nach dem Shuffle anwenden (Issue #115)', () => {
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+
+    // Mock Math.random so it always returns 0 -> predictable shuffle
+    const originalRandom = Math.random;
+    Math.random = () => 0;
+
+    act(() => {
+      result.current.starteRun(['Biologie', 'Recht'], undefined, 2);
+    });
+
+    Math.random = originalRandom;
+
+    // With always-0 random, Fisher-Yates on [1,2,3,4,5,6] produces [2,3,4,5,6,1]
+    // slice(0, 2) should give [2, 3], not [1, 2]
+    expect(result.current.aktiveFragen.length).toBe(2);
+    const ids = result.current.aktiveFragen.map(f => f.id);
+    expect(ids).toEqual(['2', '3']);
+  });
+
+  it('sollte bei Erweiterung kein Limit anwenden (Issue #115)', () => {
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+
+    act(() => {
+      result.current.starteRun(['Biologie'], undefined, 2);
+    });
+
+    expect(result.current.aktiveFragen.length).toBe(2);
+
+    act(() => {
+      result.current.starteRun(['Recht'], undefined, 2);
+    });
+
+    // Extension should add all 3 Recht questions, not limit to 2
+    expect(result.current.aktiveFragen.length).toBe(5);
+    expect(result.current.geladeneBereiche).toContain('Biologie');
+    expect(result.current.geladeneBereiche).toContain('Recht');
+  });
+
+  it('sollte ohne Limit alle Fragen verwenden (Issue #115)', () => {
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+
+    act(() => {
+      result.current.starteRun(['Biologie', 'Recht']);
+    });
+
+    expect(result.current.aktiveFragen.length).toBe(6);
+  });
 });

--- a/src/views/ProgressView.tsx
+++ b/src/views/ProgressView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { CheckCircle, XCircle, HelpCircle, ChevronDown } from 'lucide-react';
@@ -12,44 +12,58 @@ export default function ProgressView({ quiz }: Props) {
   const { statistiken, aktiveFragen, antworten, springeZuFrage, getFrageMeta } = quiz;
   const [showWrong, setShowWrong] = useState(false);
   const [showUnanswered, setShowUnanswered] = useState(false);
+  const headingRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, []);
 
   const pct = statistiken.gesamt > 0 ? (statistiken.korrekt / statistiken.gesamt) * 100 : 0;
   const passed = pct >= 60;
 
-  const bereichStats: Record<string, { korrekt: number; falsch: number; gesamt: number }> = {};
-  aktiveFragen.forEach(f => {
-    const b = f.bereich;
-    if (!bereichStats[b]) bereichStats[b] = { korrekt: 0, falsch: 0, gesamt: 0 };
-    bereichStats[b].gesamt++;
-    if (antworten[f.id] === f.richtige_antwort) bereichStats[b].korrekt++;
-    else if (antworten[f.id]) bereichStats[b].falsch++;
-  });
+   const bereichStats: Record<string, { korrekt: number; falsch: number; gesamt: number }> = useMemo(() => {
+     const stats: Record<string, { korrekt: number; falsch: number; gesamt: number }> = {};
+     aktiveFragen.forEach(f => {
+       const b = f.bereich;
+       if (!stats[b]) stats[b] = { korrekt: 0, falsch: 0, gesamt: 0 };
+       stats[b].gesamt++;
+       if (antworten[f.id] === f.richtige_antwort) stats[b].korrekt++;
+       else if (antworten[f.id]) stats[b].falsch++;
+     });
+     return stats;
+   }, [aktiveFragen, antworten]);
 
-  const falsche = aktiveFragen.filter(f => antworten[f.id] && antworten[f.id] !== f.richtige_antwort);
-  const offen = aktiveFragen.filter(f => !antworten[f.id]);
+   const falsche = useMemo(() =>
+     aktiveFragen.filter(f => antworten[f.id] && antworten[f.id] !== f.richtige_antwort),
+     [aktiveFragen, antworten]
+   );
+   const offen = useMemo(() =>
+     aktiveFragen.filter(f => !antworten[f.id]),
+     [aktiveFragen, antworten]
+   );
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-950 via-slate-900 to-teal-950">
+    <div className="min-h-screen bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-blue-950 dark:via-slate-900 dark:to-teal-950">
       <div className="container mx-auto px-3 sm:px-4 py-3 max-w-3xl pt-14 sm:pt-16">
 
         {/* Run-Ergebnis */}
-        <Card className={`mb-2 ${passed ? 'bg-emerald-900/20 border-emerald-500/30' : 'bg-red-900/20 border-red-500/30'}`}>
+        <Card className={`mb-2 ${passed ? 'bg-emerald-50 border-emerald-300/50 dark:bg-emerald-900/20 dark:border-emerald-500/30' : 'bg-red-50 border-red-300/50 dark:bg-red-900/20 dark:border-red-500/30'}`}>
           <CardContent className="py-3 px-3 text-center">
             <div className={`w-14 h-14 sm:w-16 sm:h-16 rounded-full mx-auto mb-3 flex items-center justify-center ${passed ? 'bg-emerald-500/20' : 'bg-red-500/20'}`} aria-hidden="true">
-              {passed ? <CheckCircle className="w-7 h-7 sm:w-8 sm:h-8 text-emerald-400" /> : <XCircle className="w-7 h-7 sm:w-8 sm:h-8 text-red-400" />}
+               {passed ? <CheckCircle className="w-7 h-7 sm:w-8 sm:h-8 text-emerald-600 dark:text-emerald-400" /> : <XCircle className="w-7 h-7 sm:w-8 sm:h-8 text-red-600 dark:text-red-400" />}
             </div>
-            <h2 className={`text-lg sm:text-xl font-bold mb-1 ${passed ? 'text-emerald-400' : 'text-red-400'}`}>{passed ? 'Bestanden!' : 'Nicht bestanden'}</h2>
-            <p className="text-slate-300 text-sm mb-4">{statistiken.korrekt} von {statistiken.gesamt} richtig</p>
+            <h2 ref={headingRef} tabIndex={-1} className={`text-lg sm:text-xl font-bold mb-1 outline-none ${passed ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>{passed ? 'Bestanden!' : 'Nicht bestanden'}</h2>
+            <p className="text-slate-600 text-sm mb-4 dark:text-slate-300">{statistiken.korrekt} von {statistiken.gesamt} richtig</p>
             <div className="max-w-sm mx-auto">
               <Progress
                 value={pct}
-                className="h-2 bg-slate-700"
+                className="h-2 bg-slate-200 dark:bg-slate-700"
                 aria-label={`Gesamtergebnis: ${Math.round(pct)}%`}
                 aria-valuenow={Math.round(pct)}
                 aria-valuemin={0}
                 aria-valuemax={100}
               />
-              <p className="text-slate-400 text-xs mt-1.5">{Math.round(pct)}% — 60% zum Bestehen</p>
+              <p className="text-slate-500 text-xs mt-1.5 dark:text-slate-400">{Math.round(pct)}% — 60% zum Bestehen</p>
             </div>
 
             {/* Bereichs-Stats */}
@@ -58,11 +72,11 @@ export default function ProgressView({ quiz }: Props) {
                 const p = s.gesamt > 0 ? (s.korrekt / s.gesamt) * 100 : 0;
                 return (
                   <div key={b}>
-                    <div className="flex justify-between text-xs mb-0.5">
-                      <span className="text-slate-300">{b}</span>
-                      <span className={`font-medium ${p >= 60 ? 'text-emerald-400' : 'text-red-400'}`}>{s.korrekt}/{s.gesamt} ({Math.round(p)}%)</span>
-                    </div>
-                    <Progress value={p} className="h-1.5 bg-slate-700" aria-label={`${b}: ${Math.round(p)}% richtig`} />
+                     <div className="flex justify-between text-xs mb-0.5">
+                       <span className="text-slate-600 dark:text-slate-300">{b}</span>
+                       <span className={`font-medium ${p >= 60 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>{s.korrekt}/{s.gesamt} ({Math.round(p)}%)</span>
+                     </div>
+                    <Progress value={p} className="h-1.5 bg-slate-200 dark:bg-slate-700" aria-label={`${b}: ${Math.round(p)}% richtig`} />
                   </div>
                 );
               })}
@@ -71,67 +85,68 @@ export default function ProgressView({ quiz }: Props) {
         </Card>
 
         {/* Falsche Antworten — klappbar */}
-        {falsche.length > 0 && (
-          <Card className="mb-2 bg-slate-800/50 border-slate-700/50">
-            <CardContent className="py-2 px-3">
-              <button
-                onClick={() => setShowWrong(!showWrong)}
-                aria-expanded={showWrong}
-                aria-controls="wrong-answers-list"
-                className="w-full flex items-center justify-between focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 rounded-lg"
-              >
-                <span className="text-white font-medium text-sm flex items-center gap-2">
-                  <XCircle className="w-4 h-4 text-red-400" aria-hidden="true" />
-                  Falsche Antworten ({falsche.length})
-                </span>
-                <ChevronDown className={`w-4 h-4 text-slate-400 transition-transform ${showWrong ? 'rotate-180' : ''}`} aria-hidden="true" />
-              </button>
-              {showWrong && (
+        <Card className="mb-2 bg-white/80 border-slate-200/50 dark:bg-slate-800/50 dark:border-slate-700/50">
+          <CardContent className="py-2 px-3">
+             <button
+               onClick={() => setShowWrong(!showWrong)}
+               aria-expanded={showWrong}
+               aria-controls="wrong-answers-list"
+               className="w-full flex items-center justify-between focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 rounded-lg"
+             >
+              <span className="text-slate-900 font-medium text-sm flex items-center gap-2 dark:text-white">
+                <XCircle className="w-4 h-4 text-red-600 dark:text-red-400" aria-hidden="true" />
+                Falsche Antworten ({falsche.length})
+              </span>
+              <ChevronDown className={`w-4 h-4 text-slate-500 transition-transform dark:text-slate-400 ${showWrong ? 'rotate-180' : ''}`} aria-hidden="true" />
+            </button>
+            {falsche.length === 0 ? (
+              <p className="text-emerald-600 text-sm mt-2 dark:text-emerald-400">Keine falschen Antworten — super!</p>
+            ) : showWrong && (
                 <div id="wrong-answers-list" className="mt-3 space-y-3">
                   {falsche.map(frage => {
                     const meta = getFrageMeta(frage.id);
                     return (
-                      <div key={frage.id} className="p-2.5 sm:p-3 rounded-lg bg-red-500/5 border border-red-500/10">
+                      <div key={frage.id} className="p-2.5 sm:p-3 rounded-lg bg-red-50 border border-red-200/50 dark:bg-red-500/5 dark:border-red-500/10">
                         <div className="flex items-start justify-between gap-3 mb-1.5">
-                          <p className="text-white font-medium text-sm leading-snug">{frage.frage}</p>
+                          <p className="text-slate-900 font-medium text-sm leading-snug dark:text-white">{frage.frage}</p>
                           <button
                             onClick={() => { const idx = aktiveFragen.findIndex(f => f.id === frage.id); if (idx >= 0) springeZuFrage(idx); }}
-                            className="text-teal-400 text-xs hover:underline whitespace-nowrap flex-shrink-0 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 rounded"
+                            className="text-teal-600 text-xs hover:underline whitespace-nowrap flex-shrink-0 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-teal-400 dark:focus-visible:ring-offset-slate-900 rounded"
                           >
                             Zur Frage
                           </button>
                         </div>
                         <div className="space-y-0.5 text-xs sm:text-sm">
-                          <p className="text-red-400">Deine Antwort: {antworten[frage.id]} — {frage.antworten[antworten[frage.id] as 'A' | 'B' | 'C']}</p>
-                          <p className="text-emerald-400">Richtig: {frage.richtige_antwort} — {frage.antworten[frage.richtige_antwort as 'A' | 'B' | 'C']}</p>
+                           <p className="text-red-600 dark:text-red-400">Deine Antwort: {antworten[frage.id]} — {frage.antworten[antworten[frage.id] as 'A' | 'B' | 'C']}</p>
+                           <p className="text-emerald-600 dark:text-emerald-400">Richtig: {frage.richtige_antwort} — {frage.antworten[frage.richtige_antwort as 'A' | 'B' | 'C']}</p>
                           {meta && <p className="text-slate-500 text-[10px] mt-1">Bisher {meta.attempts}×, Serie: {meta.correctStreak}</p>}
                         </div>
                       </div>
                     );
                   })}
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        )}
+                 </div>
+               )}
+             </CardContent>
+           </Card>
 
         {/* Unbeantwortete — klappbar */}
-        {offen.length > 0 && (
-          <Card className="mb-2 bg-slate-800/50 border-slate-700/50">
-            <CardContent className="py-2 px-3">
-              <button
-                onClick={() => setShowUnanswered(!showUnanswered)}
-                aria-expanded={showUnanswered}
-                aria-controls="unanswered-list"
-                className="w-full flex items-center justify-between focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 rounded-lg"
-              >
-                <span className="text-white font-medium text-sm flex items-center gap-2">
-                  <HelpCircle className="w-4 h-4 text-amber-400" aria-hidden="true" />
-                  Unbeantwortete Fragen ({offen.length})
-                </span>
-                <ChevronDown className={`w-4 h-4 text-slate-400 transition-transform ${showUnanswered ? 'rotate-180' : ''}`} aria-hidden="true" />
-              </button>
-              {showUnanswered && (
+        <Card className="mb-2 bg-white/80 border-slate-200/50 dark:bg-slate-800/50 dark:border-slate-700/50">
+          <CardContent className="py-2 px-3">
+             <button
+               onClick={() => setShowUnanswered(!showUnanswered)}
+               aria-expanded={showUnanswered}
+               aria-controls="unanswered-list"
+               className="w-full flex items-center justify-between focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 rounded-lg"
+             >
+              <span className="text-slate-900 font-medium text-sm flex items-center gap-2 dark:text-white">
+                <HelpCircle className="w-4 h-4 text-amber-400" aria-hidden="true" />
+                Unbeantwortete Fragen ({offen.length})
+              </span>
+              <ChevronDown className={`w-4 h-4 text-slate-500 transition-transform dark:text-slate-400 ${showUnanswered ? 'rotate-180' : ''}`} aria-hidden="true" />
+            </button>
+            {offen.length === 0 ? (
+              <p className="text-emerald-600 text-sm mt-2 dark:text-emerald-400">Alle Fragen beantwortet!</p>
+            ) : showUnanswered && (
                 <div id="unanswered-list" className="mt-3 flex flex-wrap gap-1.5">
                   {offen.map(frage => {
                     const idx = aktiveFragen.findIndex(f => f.id === frage.id);
@@ -140,18 +155,17 @@ export default function ProgressView({ quiz }: Props) {
                         key={frage.id}
                         onClick={() => springeZuFrage(idx)}
                         aria-label={`Zu unbeantworteter Frage ${idx + 1} springen`}
-                        className="px-2.5 py-1 rounded-md text-xs font-medium bg-amber-500/10 text-amber-400 border border-amber-500/20 hover:bg-amber-500/20 transition-all focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+                        className="px-2.5 py-1 rounded-md text-xs font-medium bg-amber-50 text-amber-600 border border-amber-300/50 hover:bg-amber-100 transition-all focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-amber-500/10 dark:text-amber-400 dark:border-amber-500/20 dark:hover:bg-amber-500/20 dark:focus-visible:ring-offset-slate-900"
                       >
                         Frage {idx + 1}
                       </button>
                     );
                   })}
                 </div>
-              )}
-            </CardContent>
-          </Card>
-        )}
-      </div>
-    </div>
-  );
+               )}
+             </CardContent>
+           </Card>
+       </div>
+     </div>
+   );
 }

--- a/src/views/QuizView.tsx
+++ b/src/views/QuizView.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import {
@@ -60,19 +60,24 @@ export default function QuizView({ quiz }: Props) {
     }
   }, [aktiveFragen, antworten]);
 
-  if (!aktuelleFrage) return null;
-
-  const userAntwort = antworten[aktuelleFrage.id];
+  const userAntwort = antworten[aktuelleFrage?.id || ''];
   const hasAnswered = userAntwort !== undefined;
   const isPending = pendingWrongAnswer !== null;
   const fortschritt = ((aktuellerIndex + 1) / aktiveFragen.length) * 100;
-  const korrekt = aktiveFragen.filter(
-    (f) => antworten[f.id] === f.richtige_antwort,
-  ).length;
-  const falsch = aktiveFragen.filter(
-    (f) => antworten[f.id] && antworten[f.id] !== f.richtige_antwort,
-  ).length;
-  const offen = aktiveFragen.filter((f) => !antworten[f.id]).length;
+  const korrekt = useMemo(() =>
+    aktiveFragen.filter((f) => antworten[f.id] === f.richtige_antwort).length,
+    [aktiveFragen, antworten]
+  );
+  const falsch = useMemo(() =>
+    aktiveFragen.filter((f) => antworten[f.id] && antworten[f.id] !== f.richtige_antwort).length,
+    [aktiveFragen, antworten]
+  );
+  const offen = useMemo(() =>
+    aktiveFragen.filter((f) => !antworten[f.id]).length,
+    [aktiveFragen, antworten]
+  );
+
+  if (!aktuelleFrage) return null;
 
   // ── Arcade-Modus: Antwort-Logik ──
   const handleAnswerClick = (buchstabe: string) => {
@@ -99,7 +104,7 @@ export default function QuizView({ quiz }: Props) {
 
   return (
     <TooltipProvider delayDuration={800}>
-      <div className="min-h-screen bg-gradient-to-br from-blue-950 via-slate-900 to-teal-950">
+      <div className="min-h-screen bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-blue-950 dark:via-slate-900 dark:to-teal-950">
         <div className="container mx-auto px-3 sm:px-4 py-3 sm:py-4 max-w-4xl pt-14 sm:pt-16">
           {/* Top Bar — Run-Stats */}
           <div className="flex items-center justify-between mb-2 sm:mb-3 gap-2">
@@ -111,6 +116,7 @@ export default function QuizView({ quiz }: Props) {
               </span>
             </div>
             <div
+              role="status"
               className="flex items-center gap-1.5"
               aria-label={`${korrekt} richtig, ${falsch} falsch, ${offen} offen`}
             >
@@ -126,7 +132,7 @@ export default function QuizView({ quiz }: Props) {
 
           {/* Progress Bar */}
           <div className="mb-3 sm:mb-4">
-            <div className="flex justify-between text-xs text-slate-400 mb-1">
+            <div className="flex justify-between text-xs text-slate-500 mb-1 dark:text-slate-400">
               <span id="progress-label">
                 Frage {aktuellerIndex + 1} / {aktiveFragen.length}
               </span>
@@ -134,7 +140,7 @@ export default function QuizView({ quiz }: Props) {
             </div>
             <Progress
               value={fortschritt}
-              className="h-1.5 bg-slate-700"
+              className="h-1.5 bg-slate-200 dark:bg-slate-700"
               aria-labelledby="progress-label"
               aria-valuenow={Math.round(fortschritt)}
               aria-valuemin={0}
@@ -143,28 +149,28 @@ export default function QuizView({ quiz }: Props) {
           </div>
 
           {/* Frage — FIXE HÖHE */}
-          <div className="bg-slate-800/60 backdrop-blur-sm border border-slate-700/50 rounded-xl p-3 sm:p-4 md:p-5 mb-3 sm:mb-4 h-[520px] sm:h-[600px] md:h-[720px] flex flex-col overflow-hidden">
+          <div className="bg-white/80 backdrop-blur-sm border border-slate-200/50 rounded-xl p-3 sm:p-4 md:p-5 mb-3 sm:mb-4 h-[520px] sm:h-[600px] md:h-[720px] flex flex-col overflow-hidden dark:bg-slate-800/60 dark:border-slate-700/50">
             {/* Themenbereich + Favorit */}
             <div className="mb-2 flex items-center justify-between">
               {aktuelleFrage.bild ? (
-                <span className="inline-block px-2.5 py-0.5 rounded-full text-[10px] font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
+                <span className="inline-block px-2.5 py-0.5 rounded-full text-[10px] font-medium bg-purple-100 text-purple-600 border border-purple-300/50 dark:bg-purple-500/10 dark:text-purple-400 dark:border-purple-500/20">
                   Bilderkennung
                 </span>
               ) : (
-                <span className="inline-block px-2.5 py-0.5 rounded-full text-[10px] font-medium bg-teal-500/10 text-teal-400 border border-teal-500/20">
+                <span className="inline-block px-2.5 py-0.5 rounded-full text-[10px] font-medium bg-teal-100 text-teal-600 border border-teal-300/50 dark:bg-teal-500/10 dark:text-teal-400 dark:border-teal-500/20">
                   {aktuelleFrage.bereich}
                 </span>
               )}
-              <button
-                onClick={() => toggleFavorite(aktuelleFrage.id)}
-                aria-label={isFavorite(aktuelleFrage.id) ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}
-                className={`p-1 rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${isFavorite(aktuelleFrage.id) ? 'text-amber-400 hover:text-amber-300' : 'text-slate-500 hover:text-amber-400'}`}
-              >
+               <button
+                 onClick={() => toggleFavorite(aktuelleFrage.id)}
+                 aria-label={isFavorite(aktuelleFrage.id) ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}
+                 className={`p-2.5 rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 ${isFavorite(aktuelleFrage.id) ? 'text-amber-400 hover:text-amber-300' : 'text-slate-400 hover:text-amber-400 dark:text-slate-500'} min-w-[44px] min-h-[44px]`}
+               >
                 <Star className={`w-5 h-5 sm:w-6 sm:h-6 ${isFavorite(aktuelleFrage.id) ? 'fill-current' : ''}`} />
               </button>
             </div>
 
-            <h2 className="text-white text-sm sm:text-base md:text-lg font-semibold mb-2 sm:mb-3 leading-snug line-clamp-3">
+            <h2 className="text-slate-900 text-sm sm:text-base md:text-lg font-semibold mb-2 sm:mb-3 leading-snug line-clamp-3 dark:text-white">
               {aktuelleFrage.frage}
             </h2>
 
@@ -173,7 +179,7 @@ export default function QuizView({ quiz }: Props) {
                 <img
                   src={aktuelleFrage.bild_url}
                   alt={`Bild zur Frage ${aktuellerIndex + 1}: ${aktuelleFrage.frage}`}
-                  className="max-w-full h-28 sm:h-36 md:h-44 object-contain rounded-lg border border-slate-600/50 bg-slate-900/50"
+                  className="max-w-full h-28 sm:h-36 md:h-44 object-contain rounded-lg border border-slate-300/50 bg-slate-100/50 dark:border-slate-600/50 dark:bg-slate-900/50"
                   loading="lazy"
                 />
               </div>
@@ -191,7 +197,7 @@ export default function QuizView({ quiz }: Props) {
                 const isPendingSelection = pendingWrongAnswer === buchstabe;
 
                 let cls =
-                  "border-slate-600/50 bg-slate-700/30 hover:bg-slate-700/50 hover:border-slate-500/50";
+                  "border-slate-300/50 bg-slate-100/80 hover:bg-slate-200/50 hover:border-slate-400/50 dark:border-slate-600/50 dark:bg-slate-700/30 dark:hover:bg-slate-700/50 dark:hover:border-slate-500/50";
                 if (hasAnswered) {
                   if (isSelected && isCorrect)
                     cls = "border-emerald-500 bg-emerald-500/10";
@@ -213,19 +219,20 @@ export default function QuizView({ quiz }: Props) {
                     key={buchstabe}
                     onClick={() => handleAnswerClick(buchstabe)}
                     disabled={isDisabled}
-                    aria-pressed={isSelected || isPendingSelection}
+                    role="radio"
+                    aria-checked={isSelected || isPendingSelection}
                     aria-disabled={isDisabled}
                     aria-label={`Antwort ${buchstabe}: ${aktuelleFrage.antworten[buchstabe]}`}
-                    className={`w-full text-left h-12 sm:h-14 rounded-lg border transition-all flex items-center gap-3 px-3 ${cls} ${isDisabled ? "cursor-default opacity-50" : "cursor-pointer focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"}`}
+                    className={`w-full text-left h-12 sm:h-14 rounded-lg border transition-all flex items-center gap-3 px-3 ${cls} ${isDisabled ? "cursor-default opacity-50" : "cursor-pointer focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"}`}
                   >
                     <span
-                      className={`flex-shrink-0 w-8 h-8 rounded-md flex items-center justify-center font-bold text-sm ${hasAnswered && isCorrect ? "bg-emerald-500 text-white" : hasAnswered && isSelected && !isCorrect ? "bg-red-500 text-white" : isPendingSelection ? "bg-red-500 text-white" : isSelected ? "bg-teal-400 text-slate-900" : "bg-slate-600/50 text-slate-300"}`}
+                      className={`flex-shrink-0 w-8 h-8 rounded-md flex items-center justify-center font-bold text-sm ${hasAnswered && isCorrect ? "bg-emerald-500 text-white" : hasAnswered && isSelected && !isCorrect ? "bg-red-500 text-white" : isPendingSelection ? "bg-red-500 text-white" : isSelected ? "bg-teal-400 text-slate-900" : "bg-slate-300/50 text-slate-600 dark:bg-slate-600/50 dark:text-slate-300"}`}
                       aria-hidden="true"
                     >
                       {buchstabe}
                     </span>
                     <span
-                      className={`flex-1 leading-snug text-sm truncate ${hasAnswered && isCorrect ? "text-emerald-300" : hasAnswered && isSelected && !isCorrect ? "text-red-300" : isPendingSelection ? "text-red-300" : "text-slate-200"}`}
+                      className={`flex-1 leading-snug text-sm truncate ${hasAnswered && isCorrect ? "text-emerald-600 dark:text-emerald-300" : hasAnswered && isSelected && !isCorrect ? "text-red-600 dark:text-red-300" : isPendingSelection ? "text-red-600 dark:text-red-300" : "text-slate-700 dark:text-slate-200"}`}
                     >
                       {aktuelleFrage.antworten[buchstabe]}
                     </span>
@@ -291,67 +298,67 @@ export default function QuizView({ quiz }: Props) {
             </div>
           </div>
 
-          {/* Navigation: Zurück + Weiter, näher zur Mitte */}
-          <div className="flex items-center justify-center gap-3">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  onClick={vorherigeFrage}
-                  disabled={aktuellerIndex === 0}
-                  variant="outline"
-                  aria-label="Vorherige Frage"
-                  className="border-slate-600 text-slate-300 hover:bg-slate-800 disabled:opacity-30 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 text-xs sm:text-sm py-2 px-4"
-                >
-                  <ChevronLeft className="w-4 h-4 mr-0.5" aria-hidden="true" />
-                  <span className="hidden sm:inline">Zurück</span>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Vorherige Frage</p>
-              </TooltipContent>
-            </Tooltip>
+           {/* Navigation: Zurück + Weiter, näher zur Mitte */}
+           <div className="flex items-center justify-center gap-3">
+             <Tooltip>
+               <TooltipTrigger asChild>
+                  <Button
+                    onClick={vorherigeFrage}
+                    disabled={aktuellerIndex === 0}
+                    variant="outline"
+                    aria-label="Vorherige Frage"
+                    className="border-slate-300 text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800 disabled:opacity-30 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 text-xs sm:text-sm min-w-[44px] min-h-[44px] py-2 px-4"
+                  >
+                   <ChevronLeft className="w-4 h-4 mr-0.5" aria-hidden="true" />
+                   <span className="hidden sm:inline">Zurück</span>
+                 </Button>
+               </TooltipTrigger>
+               <TooltipContent>
+                 <p>Vorherige Frage</p>
+               </TooltipContent>
+             </Tooltip>
 
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  onClick={naechsteFrage}
-                  disabled={
-                    aktuellerIndex === aktiveFragen.length - 1 || isPending
-                  }
-                  variant="outline"
-                  aria-label="Nächste Frage"
-                  className="border-slate-600 text-slate-300 hover:bg-slate-800 disabled:opacity-30 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 text-xs sm:text-sm py-2 px-4"
-                >
-                  <span className="hidden sm:inline">Weiter</span>
-                  <ChevronRight className="w-4 h-4 ml-0.5" aria-hidden="true" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Nächste Frage</p>
-              </TooltipContent>
-            </Tooltip>
-          </div>
+             <Tooltip>
+               <TooltipTrigger asChild>
+                  <Button
+                    onClick={naechsteFrage}
+                    disabled={
+                      aktuellerIndex === aktiveFragen.length - 1 || isPending
+                    }
+                    variant="outline"
+                    aria-label="Nächste Frage"
+                    className="border-slate-300 text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800 disabled:opacity-30 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 text-xs sm:text-sm min-w-[44px] min-h-[44px] py-2 px-4"
+                  >
+                   <span className="hidden sm:inline">Weiter</span>
+                   <ChevronRight className="w-4 h-4 ml-0.5" aria-hidden="true" />
+                 </Button>
+               </TooltipTrigger>
+               <TooltipContent>
+                 <p>Nächste Frage</p>
+               </TooltipContent>
+             </Tooltip>
+           </div>
 
           {/* Bereichs-Abschluss Dialog (Issue #46) */}
           <Dialog open={bereichComplete !== null} onOpenChange={(open) => !open && setBereichComplete(null)}>
-            <DialogContent className="bg-slate-900 border-slate-700 text-white max-w-sm">
+            <DialogContent className="bg-white border-slate-200 text-slate-900 max-w-sm dark:bg-slate-900 dark:border-slate-700 dark:text-white">
               <DialogHeader>
                 <DialogTitle className="flex items-center gap-2 text-base">
                   <CheckCircle className="w-5 h-5 text-emerald-400" />
                   Bereich abgeschlossen!
                 </DialogTitle>
-                <DialogDescription className="text-slate-400 text-sm">
+                <DialogDescription className="text-slate-500 text-sm dark:text-slate-400">
                   Du hast alle Fragen im Bereich <span className="text-teal-400 font-medium">{bereichComplete}</span> beantwortet.
                 </DialogDescription>
               </DialogHeader>
-              <p className="text-slate-300 text-sm">
+              <p className="text-slate-600 text-sm dark:text-slate-300">
                 Du kannst über die Startansicht einen weiteren Bereich hinzufügen.
               </p>
               <div className="flex gap-2 mt-2">
                 <Button
                   onClick={() => setBereichComplete(null)}
                   variant="outline"
-                  className="flex-1 border-slate-600 text-slate-300 hover:bg-slate-800 text-xs"
+                  className="flex-1 border-slate-300 text-slate-600 hover:bg-slate-100 text-xs dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
                 >
                   Weiterlernen
                 </Button>


### PR DESCRIPTION
## Summary
Fixes the bug where a question limit (e.g. Exam mode's fixed 60 questions) would be applied **before** shuffling, causing every session to draw the same deterministic subset.

## Changes
- **src/hooks/useQuiz.ts**: Added optional `limit?: number` parameter to `starteQuiz` and pass it through to `starteRun`.
- **src/store/quizRun.ts**: Added optional `limit?: number` parameter to `starteRun`. The limit is now applied **after** the Fisher-Yates shuffle for new runs, ensuring a random subset on every session.
- **Extension runs** remain unlimited so adding new areas to an active run does not re-limit existing questions.

## Acceptance Criteria
- [x] Exam mode pulls a random subset from the full pool on every new run (shuffle → slice).
- [x] Arcade / Hardcore modes without a limit remain unaffected.
- [x] Adding a new area to an active run (extension path) still works correctly and does not re-shuffle or re-limit existing questions.

Closes #115