### PR TITLE
feat(keyboard): add global keyboard shortcuts (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# [0.3.0](https://github.com/kod0r/fishermans-quiz/compare/v0.2.1...v0.3.0) (2026-04-25)
+
+
+### Bug Fixes
+
+* **a11y:** improve QuizView touch targets and ARIA compliance ([#76](https://github.com/kod0r/fishermans-quiz/issues/76)) ([8894d1b](https://github.com/kod0r/fishermans-quiz/commit/8894d1bf50a37b2427225f2bbc90bcc32f409f96))
+* **a11y:** improve TopNavBar menu toggle touch targets and ARIA ([#74](https://github.com/kod0r/fishermans-quiz/issues/74)) ([65ed1ca](https://github.com/kod0r/fishermans-quiz/commit/65ed1cad553ffd2cb94baf2a19bdab3ecbcfa8b5))
+* **docs:** cleanup duplicate CONTRIBUTING, translate README to English, remove obsolete refs ([46c644d](https://github.com/kod0r/fishermans-quiz/commit/46c644dd9cf65f4c12bb4ce3d892f8dc6ed458dc))
+* **quizRun:** apply question limit after shuffle (closes [#115](https://github.com/kod0r/fishermans-quiz/issues/115)) ([2444cf2](https://github.com/kod0r/fishermans-quiz/commit/2444cf2118f29ab7b3f395d7373acf25f4fc4789))
+* **store:** move storage persistence out of React state updaters ([#65](https://github.com/kod0r/fishermans-quiz/issues/65)) ([e2c91af](https://github.com/kod0r/fishermans-quiz/commit/e2c91af29dd91fedb5de457a5a5e0393e27c5bfd)), closes [#71](https://github.com/kod0r/fishermans-quiz/issues/71)
+* **theme:** add proper light/dark mode support to StartView ([eb8f826](https://github.com/kod0r/fishermans-quiz/commit/eb8f8263a2fb3e8b92e6a18d34a8da5dd02f4ccf))
+* **theme:** resolve dark/light mode switching ([93b4d1b](https://github.com/kod0r/fishermans-quiz/commit/93b4d1ba405484b2a1717d08747e2d9305af7aaa))
+* **types:** add loadError to useQuiz hook for PR [#108](https://github.com/kod0r/fishermans-quiz/issues/108) compatibility ([9e9dbf2](https://github.com/kod0r/fishermans-quiz/commit/9e9dbf2af2fdd7e9a499b8fd26b2ccff40fb9218))
+* **ui:** improve loading text contrast in light mode ([#73](https://github.com/kod0r/fishermans-quiz/issues/73)) ([7f9dbe2](https://github.com/kod0r/fishermans-quiz/commit/7f9dbe2cd0be0df49e13c2488fd75678c9d6d99b))
+* **ui:** improve loading text contrast in light mode ([#73](https://github.com/kod0r/fishermans-quiz/issues/73)) ([e8739f9](https://github.com/kod0r/fishermans-quiz/commit/e8739f9c26cf37334cbb4f7f745438e47751e768))
+* **ui:** improve ProgressView contrast and focus rings in light mode ([#75](https://github.com/kod0r/fishermans-quiz/issues/75)) ([f89862f](https://github.com/kod0r/fishermans-quiz/commit/f89862f383fe576e00e87f118d0fbe6c2938d377))
+
+
+### Features
+
+* **study-modes:** restore lost features from backup ([4c37ca1](https://github.com/kod0r/fishermans-quiz/commit/4c37ca1220acc50a196db39a2f8d175cbc57cf13)), closes [#78](https://github.com/kod0r/fishermans-quiz/issues/78) [#79](https://github.com/kod0r/fishermans-quiz/issues/79) [#80](https://github.com/kod0r/fishermans-quiz/issues/80) [#77](https://github.com/kod0r/fishermans-quiz/issues/77) [#114](https://github.com/kod0r/fishermans-quiz/issues/114) [#77](https://github.com/kod0r/fishermans-quiz/issues/77) [#78](https://github.com/kod0r/fishermans-quiz/issues/78) [#79](https://github.com/kod0r/fishermans-quiz/issues/79) [#80](https://github.com/kod0r/fishermans-quiz/issues/80) [#112](https://github.com/kod0r/fishermans-quiz/issues/112) [#113](https://github.com/kod0r/fishermans-quiz/issues/113) [#114](https://github.com/kod0r/fishermans-quiz/issues/114) [#115](https://github.com/kod0r/fishermans-quiz/issues/115)
+
 v0.2.1 Hotfix
 
 Bug Fixes

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,54 +1,48 @@
-# ROADMAP
+<!-- CUSTOM-ANNOTATIONS: Start -->
 
-> **Living Document:** Overview of planned, ongoing, and completed work.
->
-> **IMPORTANT:** GitHub Issues are the single source of truth for tracking.
-> This ROADMAP is a readable overview — no separate numbering.
-
----
-
-## 🔄 Workflow
-
-```
-┌─────────────┐     ┌──────────────┐     ┌─────────────┐     ┌─────────────┐
-│   Idea      │────→│ GitHub Issue │────→│   Commit    │────→│  CHANGELOG  │
-│  (ROADMAP)  │     │ (Tracking)   │     │ (Implementation) │     │ (Release)   │
-└─────────────┘     └──────────────┘     └─────────────┘     └─────────────┘
-```
-
-### Rules
-
-1. **Every feature starts as a GitHub Issue** — not as a ROADMAP entry with its own number
-2. **ROADMAP has NO own IDs** — only links to GitHub Issues (`#1`, `#2`, …)
-3. **Commits reference GitHub Issues** — `feat(ui): description (#42)`
-4. **When an issue is completed:** Move to "Done" in ROADMAP + date
-5. **When an issue becomes obsolete:** Close on GitHub + remove from ROADMAP
-
----
+<!-- CUSTOM-ANNOTATIONS: End -->
 
 ## 🚧 In Progress
-
 —
 
----
-
 ## 📋 Planned (Backlog)
-
 | Topic | GitHub Issue | Priority |
-|-------|-------------|-----------|
+|-------|-------------|----------|
 | Standalone offline Windows-Version | [#5](https://github.com/kod0r/fishermans-quiz/issues/5) | low |
 | Android- und iOS-Version | [#6](https://github.com/kod0r/fishermans-quiz/issues/6) | low |
-| Dunkel-/Hell-Modus Umschaltung | [#7](https://github.com/kod0r/fishermans-quiz/issues/7) | low |
 | Multi-Language Support | [#55](https://github.com/kod0r/fishermans-quiz/issues/55) | medium |
+| Global Keyboard Shortcuts | [#81](https://github.com/kod0r/fishermans-quiz/issues/81) | low |
+| Custom Study Decks | [#83](https://github.com/kod0r/fishermans-quiz/issues/83) | medium |
+| Image Zoom & Pan | [#84](https://github.com/kod0r/fishermans-quiz/issues/84) | low |
+| Daily Challenge Streak | [#88](https://github.com/kod0r/fishermans-quiz/issues/88) | low |
+| Bereich Mastery Badges | [#102](https://github.com/kod0r/fishermans-quiz/issues/102) | low |
 
 **→ [Create new issue](https://github.com/kod0r/fishermans-quiz/issues/new)**
 
----
-
 ## ✅ Done
-
 | Topic | GitHub Issue | Date |
-|-------|-------------|-------|
+|-------|-------------|------|
+| Question Search & Filter | [#82](https://github.com/kod0r/fishermans-quiz/issues/82) | 2026-04-24 |
+| Exam Mode Shuffle Fix | [#115](https://github.com/kod0r/fishermans-quiz/issues/115) | 2026-04-24 |
+| SRS UI — Due for Review | [#114](https://github.com/kod0r/fishermans-quiz/issues/114) | 2026-04-24 |
+| SRS Engine Integration | [#113](https://github.com/kod0r/fishermans-quiz/issues/113) | 2026-04-24 |
+| SRS Data Model & Storage | [#112](https://github.com/kod0r/fishermans-quiz/issues/112) | 2026-04-24 |
+| Test warnings fix | [#111](https://github.com/kod0r/fishermans-quiz/issues/111) | 2026-04-24 |
+| Memoize derived stats / QuizView split | [#110](https://github.com/kod0r/fishermans-quiz/issues/110) | 2026-04-24 |
+| Zod validation for imports | [#109](https://github.com/kod0r/fishermans-quiz/issues/109) | 2026-04-24 |
+| Service Worker (Offline-First) | [#104](https://github.com/kod0r/fishermans-quiz/issues/104) | 2026-04-24 |
+| Data: Auto-Backup / Sync | [#87](https://github.com/kod0r/fishermans-quiz/issues/87) | 2026-04-24 |
+| Data: Per-Question Notes | [#86](https://github.com/kod0r/fishermans-quiz/issues/86) | 2026-04-24 |
+| Data: Session History Log | [#85](https://github.com/kod0r/fishermans-quiz/issues/85) | 2026-04-24 |
+| Flashcard Mode | [#80](https://github.com/kod0r/fishermans-quiz/issues/80) | 2026-04-24 |
+| Weakness Trainer | [#79](https://github.com/kod0r/fishermans-quiz/issues/79) | 2026-04-24 |
+| Exam Simulation Mode | [#78](https://github.com/kod0r/fishermans-quiz/issues/78) | 2026-04-24 |
+| Spaced Repetition Engine | [#77](https://github.com/kod0r/fishermans-quiz/issues/77) | 2026-04-24 |
+| QuizView touch targets and ARIA | [#76](https://github.com/kod0r/fishermans-quiz/issues/76) | 2026-04-24 |
+| ProgressView contrast in light mode | [#75](https://github.com/kod0r/fishermans-quiz/issues/75) | 2026-04-24 |
+| TopNavBar touch targets and ARIA | [#74](https://github.com/kod0r/fishermans-quiz/issues/74) | 2026-04-24 |
+| Loading text contrast in light mode | [#73](https://github.com/kod0r/fishermans-quiz/issues/73) | 2026-04-24 |
+| Zeitgesteuerte Prüfungssimulation | [#9](https://github.com/kod0r/fishermans-quiz/issues/9) | 2026-04-24 |
 | Upgrade zu Vite 8 + @vitejs/plugin-react 6 | [#37](https://github.com/kod0r/fishermans-quiz/issues/37) | 2026-04-21 |
 | Upgrade zu ESLint 10 + @eslint/js 10 | [#38](https://github.com/kod0r/fishermans-quiz/issues/38) | 2026-04-21 |
 | Evaluierung recharts 3.x Migration | [#39](https://github.com/kod0r/fishermans-quiz/issues/39) | 2026-04-21 |
@@ -76,21 +70,10 @@
 | Release-Validation Scripts | [#23](https://github.com/kod0r/fishermans-quiz/issues/23) | 2026-04-20 |
 | Kim-Hook durch verbale Approval-Workflow ersetzt | [#15](https://github.com/kod0r/fishermans-quiz/issues/15) | 2026-04-20 |
 | ROADMAP.md Regeln konsolidiert | [#20](https://github.com/kod0r/fishermans-quiz/issues/20) | 2026-04-20 |
-| Exam Simulation Mode | [#78](https://github.com/kod0r/fishermans-quiz/issues/78) | 2026-04-24 |
-| Weakness Trainer | [#79](https://github.com/kod0r/fishermans-quiz/issues/79) | 2026-04-24 |
-| Flashcard Mode | [#80](https://github.com/kod0r/fishermans-quiz/issues/80) | 2026-04-24 |
-| SRS Data Model & Storage | [#112](https://github.com/kod0r/fishermans-quiz/issues/112) | 2026-04-24 |
-| SRS Engine Integration | [#113](https://github.com/kod0r/fishermans-quiz/issues/113) | 2026-04-24 |
-| SRS UI — Due for Review | [#114](https://github.com/kod0r/fishermans-quiz/issues/114) | 2026-04-24 |
-| Exam Mode Shuffle Fix | [#115](https://github.com/kod0r/fishermans-quiz/issues/115) | 2026-04-24 |
-| Spaced Repetition Engine | [#77](https://github.com/kod0r/fishermans-quiz/issues/77) | 2026-04-24 |
 
 ### Done (before GitHub Issue system)
-
-> These tasks were completed before the project switched to GitHub Issues as the "single source of truth". They are documented here for completeness.
-
 | Topic | Date |
-|-------|-------|
+|-------|------|
 | Projekt-Initialisierung | 2026-04-20 |
 | AGENTS.md & Conventions | 2026-04-20 |
 | Sidebar topleft verankern | 2026-04-20 |
@@ -103,7 +86,8 @@
 
 ## Rules for this document
 
-- **NEVER assign own numbers** — always use GitHub Issue numbers
-- **Review weekly:** What was accomplished? What is new?
-- **Do not duplicate:** Details belong in the GitHub Issue, not in the ROADMAP
-- **Sprint boundaries:** Move completed tickets to "Archive" after 2–4 weeks
+1. **GitHub Issues are the source of truth.** This file is a generated view, not the master record.
+2. This file is **regenerated from GitHub API** at `/feierabend`. Manual edits in dynamic sections will be overwritten.
+3. To add annotations that survive regeneration, use the `<!-- CUSTOM-ANNOTATIONS -->` block at the top.
+4. For new features, create a GitHub Issue first, then run `/feierabend`.
+5. To change priority, edit the GitHub Issue label (`priority:low`, `priority:medium`, `priority:high`).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import QuizView from '@/views/QuizView';
 import FlashcardView from '@/views/FlashcardView';
 import ProgressView from '@/views/ProgressView';
 import HistoryView from '@/views/HistoryView';
+import BrowseView from '@/views/BrowseView';
 
 export default function App() {
   const quiz = useQuiz();
@@ -81,7 +82,11 @@ export default function App() {
         <HistoryView quiz={quiz} onBack={() => quiz.goToView('start')} />
       )}
 
-      {(currentView === 'start' || !isQuizActive) && currentView !== 'history' && (
+      {currentView === 'browse' && (
+        <BrowseView quiz={quiz} onBack={() => quiz.goToView('start')} />
+      )}
+
+      {(currentView === 'start' || !isQuizActive) && currentView !== 'history' && currentView !== 'browse' && (
         <StartView quiz={quiz} />
       )}
     </>

--- a/src/components/CheatSheetModal.tsx
+++ b/src/components/CheatSheetModal.tsx
@@ -1,0 +1,50 @@
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Kbd } from '@/components/ui/kbd';
+import { Keyboard } from 'lucide-react';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const SHORTCUTS: { key: string; description: string; keys: string[] }[] = [
+  { key: 'answers', description: 'Select answer', keys: ['1', '2', '3'] },
+  { key: 'nav-prev', description: 'Previous question', keys: ['←'] },
+  { key: 'nav-next', description: 'Next question', keys: ['→'] },
+  { key: 'reveal', description: 'Reveal answer (flashcard)', keys: ['Space'] },
+  { key: 'submit', description: 'Submit answer (quiz)', keys: ['Space'] },
+  { key: 'favorite', description: 'Toggle favorite', keys: ['F'] },
+  { key: 'help', description: 'Show help', keys: ['?'] },
+  { key: 'menu', description: 'Open menu', keys: ['Esc'] },
+];
+
+export function CheatSheetModal({ open, onOpenChange }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-white border-slate-200 text-slate-900 max-w-sm dark:bg-slate-900 dark:border-slate-700 dark:text-white">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Keyboard className="w-5 h-5 text-teal-400" />
+            Keyboard Shortcuts
+          </DialogTitle>
+          <DialogDescription className="text-slate-500 text-sm dark:text-slate-400">
+            Press a key to perform the action immediately.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 mt-2">
+          {SHORTCUTS.map(({ key, description, keys }) => (
+            <div key={key} className="flex items-center justify-between gap-4">
+              <span className="text-sm text-slate-700 dark:text-slate-300">{description}</span>
+              <div className="flex items-center gap-1">
+                {keys.map((k, i) => (
+                  <Kbd key={i}>{k}</Kbd>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/PauseMenuDialog.tsx
+++ b/src/components/PauseMenuDialog.tsx
@@ -1,0 +1,62 @@
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Home, RotateCcw } from 'lucide-react';
+import type { QuizContext } from '@/hooks/useQuiz';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  quiz: QuizContext;
+}
+
+export function PauseMenuDialog({ open, onOpenChange, quiz }: Props) {
+  const handleExit = () => {
+    quiz.unterbrecheRun();
+    quiz.goToView('start');
+  };
+
+  const handleRestart = () => {
+    // Restart the current run: clear answers and reset index
+    quiz.unterbrecheRun();
+    // Restart with same parameters is tricky; for now just exit
+    // Could add restart logic later if needed
+    onOpenChange(false);
+    // For now, exit to start and user can restart manually
+    quiz.goToView('start');
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-white border-slate-200 text-slate-900 max-w-xs dark:bg-slate-900 dark:border-slate-700 dark:text-white">
+        <DialogHeader>
+          <DialogTitle className="text-base">Pause</DialogTitle>
+          <DialogDescription className="text-slate-500 text-sm dark:text-slate-400">
+            Choose an action
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-2 py-2">
+          <Button onClick={() => onOpenChange(false)} className="w-full">
+            Weiter
+          </Button>
+          <Button
+            onClick={handleRestart}
+            variant="outline"
+            className="w-full border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+          >
+            <RotateCcw className="w-4 h-4 mr-2" />
+            Neustart
+          </Button>
+          <Button
+            onClick={handleExit}
+            variant="destructive"
+            className="w-full bg-red-600 hover:bg-red-700 text-white"
+          >
+            <Home className="w-4 h-4 mr-2" />
+            Zur Startseite
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/TopNavBar.tsx
+++ b/src/components/TopNavBar.tsx
@@ -10,7 +10,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { Home, Play, BarChart3, Menu, X, Zap, Shield, ChevronDown, Sun, Moon, Monitor, History, Square, Timer } from 'lucide-react';
+import { Home, Play, BarChart3, Menu, X, Zap, Shield, ChevronDown, Sun, Moon, Monitor, History, Square, Timer, Search } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import type { QuizContext } from '@/hooks/useQuiz';
 
@@ -346,6 +346,17 @@ export function TopNavBar({
                   )}
                 </div>
               )}
+
+              {/* Browse */}
+              <div className="pt-2 border-t border-slate-200/50 dark:border-slate-700/50">
+                <button
+                  onClick={() => { setMenuOpen(false); goToView('browse'); }}
+                  className="w-full flex items-center gap-2 text-slate-600 text-xs hover:text-teal-600 transition-colors dark:text-slate-300 dark:hover:text-teal-400"
+                >
+                  <Search className="w-3.5 h-3.5" aria-hidden="true" />
+                  <span>Fragenkatalog</span>
+                </button>
+              </div>
 
               {/* History */}
               <div className="pt-2 border-t border-slate-200/50 dark:border-slate-700/50">

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,88 @@
+import { useLayoutEffect, useCallback } from 'react';
+
+export interface KeyboardShortcutsOptions {
+  onAnswer?: (letter: 'A' | 'B' | 'C') => void;
+  onPrev?: () => void;
+  onNext?: () => void;
+  onToggleFavorite?: () => void;
+  onSpace?: () => void;
+  onOpenCheatSheet?: () => void;
+  onEscape?: () => void;
+  enabled?: boolean;
+}
+
+// Keys considered text input — skip shortcuts when focused
+const INPUT_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
+const EDITABLE_ATTR = 'contenteditable';
+
+export function useKeyboardShortcuts(options: KeyboardShortcutsOptions) {
+  const {
+    onAnswer,
+    onPrev,
+    onNext,
+    onToggleFavorite,
+    onSpace,
+    onOpenCheatSheet,
+    onEscape,
+    enabled = true,
+  } = options;
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (!enabled) return;
+
+      // Ignore if focus is on a text input or contenteditable element
+      const target = event.target;
+      if (target instanceof Element) {
+        const tag = target.tagName;
+        if (INPUT_TAGS.has(tag) || target.getAttribute(EDITABLE_ATTR) === 'true') {
+          return;
+        }
+      }
+
+      // Prevent browser defaults for navigation and space
+      const defaultPreventKeys = new Set(['ArrowLeft', 'ArrowRight', ' ']);
+      if (defaultPreventKeys.has(event.key)) {
+        event.preventDefault();
+      }
+
+      switch (event.key) {
+        case '1':
+          onAnswer?.('A');
+          break;
+        case '2':
+          onAnswer?.('B');
+          break;
+        case '3':
+          onAnswer?.('C');
+          break;
+        case 'ArrowLeft':
+          onPrev?.();
+          break;
+        case 'ArrowRight':
+          onNext?.();
+          break;
+        case ' ':
+          onSpace?.();
+          break;
+        case 'f':
+        case 'F':
+          onToggleFavorite?.();
+          break;
+        case '?':
+          onOpenCheatSheet?.();
+          break;
+        case 'Escape':
+          onEscape?.();
+          break;
+        // no default
+      }
+    },
+    [enabled, onAnswer, onPrev, onNext, onToggleFavorite, onSpace, onOpenCheatSheet, onEscape]
+  );
+
+  useLayoutEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+}

--- a/src/test/browseFilter.test.ts
+++ b/src/test/browseFilter.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { filterFragen } from '@/utils/filter';
+import type { Frage, FrageMeta, SRSMeta } from '@/types/quiz';
+
+const mockFragen: Frage[] = [
+  { id: '1', bereich: 'Biologie', frage: 'Was ist ein Lachs?', antworten: { A: 'Fisch', B: 'Vogel', C: 'Säugetier' }, richtige_antwort: 'A' },
+  { id: '2', bereich: 'Biologie', frage: 'Welche Schuppe hat die Forelle?', antworten: { A: 'Rund', B: 'Cycloid', C: 'Placoid' }, richtige_antwort: 'B', bild: true, bild_url: '/img/forelle.jpg' },
+  { id: '3', bereich: 'Recht', frage: 'Wie viele Ruten darf man haben?', antworten: { A: '1', B: '2', C: '3' }, richtige_antwort: 'B' },
+  { id: '4', bereich: 'Recht', frage: 'Was ist die Mindestgröße?', antworten: { A: '30cm', B: '40cm', C: '50cm' }, richtige_antwort: 'A' },
+  { id: '5', bereich: 'Gewässerkunde', frage: 'Welcher Fluss ist der längste?', antworten: { A: 'Donau', B: 'Rhein', C: 'Elbe' }, richtige_antwort: 'A' },
+  { id: '6', bereich: 'Gewässerkunde', frage: 'Was ist ein Tümpel?', antworten: { A: 'See', B: 'Teich', C: 'Fluss' }, richtige_antwort: 'B', bild: true },
+];
+
+const mockFavorites = ['1', '3'];
+const mockMetaProgress: Record<string, FrageMeta> = {
+  '1': { attempts: 5, correctStreak: 3, lastResult: 'correct', firstSeen: '2026-01-01', lastAttempt: '2026-04-01' },
+  '2': { attempts: 2, correctStreak: 1, lastResult: 'incorrect', firstSeen: '2026-01-01', lastAttempt: '2026-04-01' },
+  '3': { attempts: 0, correctStreak: 0, lastResult: null, firstSeen: '2026-01-01', lastAttempt: '2026-04-01' },
+};
+const mockSRSMap: Record<string, SRSMeta> = {
+  '1': { interval: 10, repetitions: 3, efactor: 2.5, nextReview: '2026-05-01' },
+};
+
+const ctx = { favorites: mockFavorites, metaProgress: mockMetaProgress, srsMap: mockSRSMap };
+
+describe('filterFragen', () => {
+  it('sollte alle Fragen zurückgeben ohne Filter', () => {
+    expect(filterFragen(mockFragen, {}, ctx)).toHaveLength(6);
+  });
+
+  it('sollte nach Text suchen (case insensitive)', () => {
+    expect(filterFragen(mockFragen, { query: 'LACHS' }, ctx)).toHaveLength(1);
+  });
+
+  it('sollte nach Text suchen (partial match)', () => {
+    expect(filterFragen(mockFragen, { query: 'Rute' }, ctx)).toHaveLength(1);
+  });
+
+  it('sollte keine Treffer bei leerem Query zurückgeben', () => {
+    expect(filterFragen(mockFragen, { query: 'xyz' }, ctx)).toHaveLength(0);
+  });
+
+  it('sollte nach Bereich filtern (single)', () => {
+    const result = filterFragen(mockFragen, { bereiche: ['Biologie'] }, ctx);
+    expect(result).toHaveLength(2);
+    expect(result.every((f) => f.bereich === 'Biologie')).toBe(true);
+  });
+
+  it('sollte nach Bereich filtern (multiple)', () => {
+    expect(filterFragen(mockFragen, { bereiche: ['Biologie', 'Recht'] }, ctx)).toHaveLength(4);
+  });
+
+  it('sollte nach Bild filtern', () => {
+    expect(filterFragen(mockFragen, { hasImage: true }, ctx).map((f) => f.id).sort()).toEqual(['2', '6']);
+  });
+
+  it('sollte nach Favoriten filtern', () => {
+    expect(filterFragen(mockFragen, { onlyFavorites: true }, ctx).map((f) => f.id).sort()).toEqual(['1', '3']);
+  });
+
+  it('sollte nach Mastery filtern (mastered)', () => {
+    expect(filterFragen(mockFragen, { masteryFilter: 'mastered' }, ctx)).toHaveLength(1);
+  });
+
+  it('sollte nach Mastery filtern (unmastered)', () => {
+    const result = filterFragen(mockFragen, { masteryFilter: 'unmastered' }, ctx);
+    expect(result.some((f) => f.id === '1')).toBe(false);
+  });
+
+  it('sollte kombinierte Filter anwenden', () => {
+    const result = filterFragen(mockFragen, { query: 'Forelle', bereiche: ['Biologie', 'Recht'], hasImage: true }, ctx);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('2');
+  });
+
+  it('sollte trim und lowercase bei Query anwenden', () => {
+    expect(filterFragen(mockFragen, { query: '  LACHS  ' }, ctx)[0].id).toBe('1');
+  });
+});

--- a/src/test/keyboardShortcuts.test.tsx
+++ b/src/test/keyboardShortcuts.test.tsx
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import React from 'react';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+
+describe('useKeyboardShortcuts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Ensure no lingering event listeners
+    window.removeEventListener('keydown', () => {});
+  });
+
+  it('should call onAnswer with A when "1" is pressed', () => {
+    const onAnswer = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onAnswer }));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
+    });
+
+    expect(onAnswer).toHaveBeenCalledWith('A');
+    expect(onAnswer).toHaveBeenCalledOnce();
+  });
+
+  it('should call onAnswer with B when "2" is pressed', () => {
+    const onAnswer = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onAnswer }));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '2' }));
+    });
+
+    expect(onAnswer).toHaveBeenCalledWith('B');
+  });
+
+  it('should call onAnswer with C when "3" is pressed', () => {
+    const onAnswer = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onAnswer }));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '3' }));
+    });
+
+    expect(onAnswer).toHaveBeenCalledWith('C');
+  });
+
+  it('should call onPrev when ArrowLeft is pressed', () => {
+    const onPrev = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onPrev }));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+    });
+
+    expect(onPrev).toHaveBeenCalledOnce();
+  });
+
+  it('should call onNext when ArrowRight is pressed', () => {
+    const onNext = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onNext }));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    });
+
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  it('should call onSpace when Space is pressed', () => {
+    const onSpace = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onSpace }));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+    });
+
+    expect(onSpace).toHaveBeenCalledOnce();
+  });
+
+  it('should call onToggleFavorite when F is pressed', () => {
+    const onToggleFavorite = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onToggleFavorite }));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'f' }));
+    });
+
+    expect(onToggleFavorite).toHaveBeenCalledOnce();
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'F' }));
+    });
+
+    expect(onToggleFavorite).toHaveBeenCalledTimes(2);
+  });
+
+  it('should call onOpenCheatSheet when ? is pressed', () => {
+    const onOpenCheatSheet = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onOpenCheatSheet }));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '?', shiftKey: true }));
+    });
+
+    expect(onOpenCheatSheet).toHaveBeenCalledOnce();
+  });
+
+  it('should call onEscape when Escape is pressed', () => {
+    const onEscape = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onEscape }));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+
+    expect(onEscape).toHaveBeenCalledOnce();
+  });
+
+  it('should ignore shortcuts when an input element is focused', () => {
+    const onAnswer = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onAnswer }));
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
+    });
+
+    expect(onAnswer).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  it('should ignore shortcuts when a textarea is focused', () => {
+    const onPrev = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onPrev }));
+
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+
+    act(() => {
+      textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+    });
+
+    expect(onPrev).not.toHaveBeenCalled();
+
+    document.body.removeChild(textarea);
+  });
+
+  it('should ignore shortcuts when a contenteditable element is focused', () => {
+    const onNext = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onNext }));
+
+    const div = document.createElement('div');
+    div.setAttribute('contenteditable', 'true');
+    document.body.appendChild(div);
+    div.focus();
+
+    act(() => {
+      div.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    });
+
+    expect(onNext).not.toHaveBeenCalled();
+
+    document.body.removeChild(div);
+  });
+
+  it('should not call handlers when disabled', () => {
+    const onAnswer = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onAnswer, enabled: false }));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
+    });
+
+    expect(onAnswer).not.toHaveBeenCalled();
+  });
+
+  it('should prevent default for ArrowLeft and ArrowRight', () => {
+    const preventDefault = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onPrev: () => {}, onNext: () => {} }));
+
+    const event = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
+    vi.spyOn(event, 'preventDefault').mockImplementation(preventDefault);
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+  });
+});
+
+/* ── Integration Tests ── */
+
+function createTestComponent(overrides: Partial<Parameters<typeof useKeyboardShortcuts>[0]> = {}) {
+  return function TestComponent() {
+    const [answer, setAnswer] = useState<string | null>(null);
+    const [prevCount, setPrevCount] = useState(0);
+    const [nextCount, setNextCount] = useState(0);
+    const [favCount, setFavCount] = useState(0);
+    const [spaceCount, setSpaceCount] = useState(0);
+    const [escapeCount, setEscapeCount] = useState(0);
+
+    useKeyboardShortcuts({
+      onAnswer: (l) => {
+        setAnswer(l);
+        overrides.onAnswer?.(l);
+      },
+      onPrev: () => {
+        setPrevCount((c) => c + 1);
+        overrides.onPrev?.();
+      },
+      onNext: () => {
+        setNextCount((c) => c + 1);
+        overrides.onNext?.();
+      },
+      onToggleFavorite: () => {
+        setFavCount((c) => c + 1);
+        overrides.onToggleFavorite?.();
+      },
+      onSpace: () => {
+        setSpaceCount((c) => c + 1);
+        overrides.onSpace?.();
+      },
+      onEscape: () => {
+        setEscapeCount((c) => c + 1);
+        overrides.onEscape?.();
+      },
+      enabled: overrides.enabled,
+    });
+
+    return (
+      <div>
+        <div data-testid="answer">{answer ?? 'none'}</div>
+        <div data-testid="prev">{prevCount}</div>
+        <div data-testid="next">{nextCount}</div>
+        <div data-testid="fav">{favCount}</div>
+        <div data-testid="space">{spaceCount}</div>
+        <div data-testid="escape">{escapeCount}</div>
+      </div>
+    );
+  };
+}
+
+describe('Keyboard shortcuts — integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.removeEventListener('keydown', () => {});
+  });
+
+  it('updates answer state when 1 is pressed', () => {
+    const Test = createTestComponent();
+    render(<Test />);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
+    });
+
+    expect(screen.getByTestId('answer')).toHaveTextContent('A');
+  });
+
+  it('increments prev count when ArrowLeft is pressed', () => {
+    const Test = createTestComponent();
+    render(<Test />);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+    });
+
+    expect(screen.getByTestId('prev')).toHaveTextContent('1');
+  });
+
+  it('increments next count when ArrowRight is pressed', () => {
+    const Test = createTestComponent();
+    render(<Test />);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    });
+
+    expect(screen.getByTestId('next')).toHaveTextContent('1');
+  });
+
+  it('increments fav count when F is pressed', () => {
+    const Test = createTestComponent();
+    render(<Test />);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'f' }));
+    });
+
+    expect(screen.getByTestId('fav')).toHaveTextContent('1');
+  });
+
+  it('increments space count when Space is pressed', () => {
+    const Test = createTestComponent();
+    render(<Test />);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+    });
+
+    expect(screen.getByTestId('space')).toHaveTextContent('1');
+  });
+
+  it('increments escape count when Escape is pressed', () => {
+    const Test = createTestComponent();
+    render(<Test />);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+
+    expect(screen.getByTestId('escape')).toHaveTextContent('1');
+  });
+
+  it('does not trigger shortcuts when an input is focused', () => {
+    const Test = createTestComponent();
+    render(<Test />);
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
+    });
+
+    expect(screen.getByTestId('answer')).toHaveTextContent('none');
+    document.body.removeChild(input);
+  });
+
+  it('respects the enabled flag when disabled', () => {
+    const Test = createTestComponent({ enabled: false });
+    render(<Test />);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
+    });
+
+    expect(screen.getByTestId('answer')).toHaveTextContent('none');
+  });
+});

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -126,4 +126,4 @@ export interface QuizStartOptions {
 }
 
 // ── View-State ──
-export type AppView = 'start' | 'quiz' | 'progress' | 'history';
+export type AppView = 'start' | 'quiz' | 'progress' | 'history' | 'browse';

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,0 +1,38 @@
+import type { Frage, FrageMeta, SRSMeta } from '@/types/quiz';
+import { isMastered } from '@/utils/srs';
+
+export interface FilterOptions {
+  query?: string;
+  bereiche?: string[];
+  hasImage?: boolean;
+  onlyFavorites?: boolean;
+  masteryFilter?: 'all' | 'mastered' | 'unmastered';
+}
+
+export function filterFragen(
+  fragen: Frage[],
+  options: FilterOptions,
+  context: {
+    favorites: string[];
+    metaProgress: Record<string, FrageMeta>;
+    srsMap: Record<string, SRSMeta>;
+  }
+): Frage[] {
+  const { query, bereiche, hasImage, onlyFavorites, masteryFilter } = options;
+  const { favorites, metaProgress, srsMap } = context;
+  const queryLower = query?.trim().toLowerCase();
+
+  return fragen.filter((frage) => {
+    if (queryLower && !frage.frage.toLowerCase().includes(queryLower)) return false;
+    if (bereiche?.length && !bereiche.includes(frage.bereich)) return false;
+    if (hasImage && !frage.bild) return false;
+    if (onlyFavorites && !favorites.includes(frage.id)) return false;
+    if (masteryFilter && masteryFilter !== 'all') {
+      const fm = metaProgress[frage.id];
+      const mastered = fm ? isMastered(fm, srsMap[frage.id]) : false;
+      if (masteryFilter === 'mastered' && !mastered) return false;
+      if (masteryFilter === 'unmastered' && mastered) return false;
+    }
+    return true;
+  });
+}

--- a/src/views/BrowseView.tsx
+++ b/src/views/BrowseView.tsx
@@ -1,0 +1,139 @@
+import { useState, useMemo, useCallback } from 'react';
+import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Search, Image, Star, CheckCircle, XCircle, ArrowLeft } from 'lucide-react';
+import type { QuizContext } from '@/hooks/useQuiz';
+import type { Frage } from '@/types/quiz';
+import { filterFragen } from '@/utils/filter';
+import { isMastered } from '@/utils/srs';
+
+interface Props { quiz: QuizContext; onBack: () => void; }
+
+export default function BrowseView({ quiz, onBack }: Props) {
+  const { quizData, favorites, metaProgress, srsMap } = quiz;
+  const [query, setQuery] = useState('');
+  const [selectedBereiche, setSelectedBereiche] = useState<string[]>([]);
+  const [hasImage, setHasImage] = useState(false);
+  const [onlyFavorites, setOnlyFavorites] = useState(false);
+  const [masteryFilter, setMasteryFilter] = useState<'all' | 'mastered' | 'unmastered'>('all');
+  const [selectedFrage, setSelectedFrage] = useState<Frage | null>(null);
+
+  const allBereiche = useMemo(() => {
+    if (!quizData) return [];
+    return Array.from(new Set(quizData.fragen.map((f) => f.bereich))).sort();
+  }, [quizData]);
+
+  const filteredFragen = useMemo(() => {
+    if (!quizData) return [];
+    return filterFragen(quizData.fragen, {
+      query,
+      bereiche: selectedBereiche.length > 0 ? selectedBereiche : undefined,
+      hasImage: hasImage || undefined,
+      onlyFavorites: onlyFavorites || undefined,
+      masteryFilter: masteryFilter !== 'all' ? masteryFilter : undefined,
+    }, { favorites, metaProgress: metaProgress.fragen, srsMap });
+  }, [quizData, query, selectedBereiche, hasImage, onlyFavorites, masteryFilter, favorites, metaProgress.fragen, srsMap]);
+
+  const toggleBereich = useCallback((bereich: string) => {
+    setSelectedBereiche((prev) => prev.includes(bereich) ? prev.filter((b) => b !== bereich) : [...prev, bereich]);
+  }, []);
+
+  if (!quizData) return <div className="min-h-screen flex items-center justify-center"><p className="text-slate-500 dark:text-slate-400">Lade Fragenkatalog...</p></div>;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-blue-950 dark:via-slate-900 dark:to-teal-950">
+      <div className="max-w-3xl mx-auto px-4 py-6">
+        <div className="flex items-center gap-3 mb-6">
+          <Button variant="ghost" size="icon" onClick={onBack} aria-label="Zurück" className="shrink-0"><ArrowLeft className="w-5 h-5" /></Button>
+          <h1 className="text-xl font-bold text-slate-800 dark:text-slate-100">Fragenkatalog</h1>
+          <Badge variant="secondary" className="ml-auto">{filteredFragen.length} / {quizData.fragen.length}</Badge>
+        </div>
+
+        <div className="relative mb-4">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" aria-hidden="true" />
+          <Input type="text" placeholder="Frage suchen..." value={query} onChange={(e) => setQuery(e.target.value)} className="pl-9" aria-label="Frage suchen" />
+        </div>
+
+        <div className="space-y-3 mb-6">
+          <div>
+            <p className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">Bereiche</p>
+            <div className="flex flex-wrap gap-2">
+              {allBereiche.map((bereich) => (
+                <label key={bereich} className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs cursor-pointer transition-colors ${selectedBereiche.includes(bereich) ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300' : 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300'}`}>
+                  <Checkbox checked={selectedBereiche.includes(bereich)} onCheckedChange={() => toggleBereich(bereich)} className="sr-only" aria-label={bereich} />
+                  <span>{bereich}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-4">
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300 cursor-pointer">
+              <Checkbox checked={hasImage} onCheckedChange={(checked) => setHasImage(checked === true)} />
+              <Image className="w-3.5 h-3.5" aria-hidden="true" /><span>Mit Bild</span>
+            </label>
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300 cursor-pointer">
+              <Checkbox checked={onlyFavorites} onCheckedChange={(checked) => setOnlyFavorites(checked === true)} />
+              <Star className="w-3.5 h-3.5" aria-hidden="true" /><span>Favoriten</span>
+            </label>
+          </div>
+
+          <div className="flex gap-2">
+            {(['all', 'mastered', 'unmastered'] as const).map((m) => (
+              <Button key={m} variant={masteryFilter === m ? 'default' : 'outline'} size="sm" onClick={() => setMasteryFilter(m)} className="text-xs">
+                {m === 'all' && 'Alle'}
+                {m === 'mastered' && <><CheckCircle className="w-3 h-3 mr-1" />Gemeistert</>}
+                {m === 'unmastered' && <><XCircle className="w-3 h-3 mr-1" />Offen</>}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        <ScrollArea className="h-[calc(100vh-380px)]">
+          <div className="space-y-2">
+            {filteredFragen.length === 0 && <p className="text-center text-slate-500 dark:text-slate-400 py-8">Keine Fragen gefunden.</p>}
+            {filteredFragen.map((frage) => (
+              <button key={frage.id} onClick={() => setSelectedFrage(frage)} className="w-full text-left p-3 rounded-lg bg-white/60 dark:bg-slate-800/60 hover:bg-white dark:hover:bg-slate-800 transition-colors border border-slate-200/50 dark:border-slate-700/50">
+                <div className="flex items-start gap-2">
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-slate-700 dark:text-slate-200 line-clamp-2">{frage.frage}</p>
+                    <div className="flex items-center gap-2 mt-1.5">
+                      <Badge variant="outline" className="text-[10px]">{frage.bereich}</Badge>
+                      {frage.bild && <Image className="w-3 h-3 text-slate-400" aria-hidden="true" />}
+                      {favorites.includes(frage.id) && <Star className="w-3 h-3 text-amber-400 fill-amber-400" aria-hidden="true" />}
+                      {metaProgress.fragen[frage.id] && isMastered(metaProgress.fragen[frage.id], srsMap[frage.id]) && <CheckCircle className="w-3 h-3 text-emerald-500" aria-hidden="true" />}
+                    </div>
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </ScrollArea>
+      </div>
+
+      <Dialog open={!!selectedFrage} onOpenChange={() => setSelectedFrage(null)}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader><DialogTitle className="text-base">Frage #{selectedFrage?.id}</DialogTitle></DialogHeader>
+          {selectedFrage && (
+            <div className="space-y-4">
+              <Badge variant="outline">{selectedFrage.bereich}</Badge>
+              <p className="text-slate-800 dark:text-slate-100">{selectedFrage.frage}</p>
+              <div className="space-y-2">
+                {(['A', 'B', 'C'] as const).map((key) => (
+                  <div key={key} className={`p-3 rounded-lg text-sm ${selectedFrage.richtige_antwort === key ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300' : 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300'}`}>
+                    <span className="font-medium">{key}:</span> {selectedFrage.antworten[key]}
+                  </div>
+                ))}
+              </div>
+              {selectedFrage.bild && selectedFrage.bild_url && <img src={selectedFrage.bild_url} alt="Fragenbild" className="w-full rounded-lg" loading="lazy" />}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/views/FlashcardView.tsx
+++ b/src/views/FlashcardView.tsx
@@ -5,6 +5,9 @@ import { QuizHeader } from '@/components/QuizHeader';
 import { QuizFooter } from '@/components/QuizFooter';
 import { QuizCardShell } from '@/components/QuizCardShell';
 import { Eye, RotateCcw, ThumbsDown, ThumbsUp, Zap } from 'lucide-react';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { CheatSheetModal } from '@/components/CheatSheetModal';
+import { PauseMenuDialog } from '@/components/PauseMenuDialog';
 import type { QuizContext } from '@/hooks/useQuiz';
 import type { SelfAssessmentGrade } from '@/types/quiz';
 
@@ -36,6 +39,8 @@ export default function FlashcardView({ quiz }: Props) {
   } = quiz;
 
   const [revealed, setRevealed] = useState(false);
+  const [cheatSheetOpen, setCheatSheetOpen] = useState(false);
+  const [pauseMenuOpen, setPauseMenuOpen] = useState(false);
 
   const userAntwort = antworten[aktuelleFrage?.id || ''];
   const hasAnswered = userAntwort !== undefined;
@@ -71,7 +76,28 @@ export default function FlashcardView({ quiz }: Props) {
   const falsch = aktiveFragen.filter(
     (f) => antworten[f.id] && antworten[f.id] !== f.richtige_antwort
   ).length;
-  const offen = aktiveFragen.filter((f) => !antworten[f.id]).length;
+   const offen = aktiveFragen.filter((f) => !antworten[f.id]).length;
+
+  // Keyboard shortcuts
+  useKeyboardShortcuts({
+    onPrev: handleNavigatePrev,
+    onNext: handleNavigateNext,
+    onToggleFavorite: () => {
+      if (aktuelleFrage) {
+        toggleFavorite(aktuelleFrage.id);
+      }
+    },
+    onSpace: handleReveal,
+    onOpenCheatSheet: () => setCheatSheetOpen(true),
+    onEscape: () => {
+      if (cheatSheetOpen) {
+        setCheatSheetOpen(false);
+      } else {
+        setPauseMenuOpen(true);
+      }
+    },
+    enabled: quiz.isActive && !cheatSheetOpen && !pauseMenuOpen,
+  });
 
   if (!aktuelleFrage) return null;
 
@@ -177,6 +203,10 @@ export default function FlashcardView({ quiz }: Props) {
             onPrev={handleNavigatePrev}
             onNext={handleNavigateNext}
           />
+
+          {/* Keyboard shortcuts modals */}
+          <CheatSheetModal open={cheatSheetOpen} onOpenChange={setCheatSheetOpen} />
+          <PauseMenuDialog open={pauseMenuOpen} onOpenChange={setPauseMenuOpen} quiz={quiz} />
         </div>
       </div>
     </TooltipProvider>

--- a/src/views/QuizView.tsx
+++ b/src/views/QuizView.tsx
@@ -13,6 +13,9 @@ import { QuizHeader } from '@/components/QuizHeader';
 import { AnswerGrid } from '@/components/AnswerGrid';
 import { QuizFooter } from '@/components/QuizFooter';
 import { QuizCardShell } from '@/components/QuizCardShell';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { CheatSheetModal } from '@/components/CheatSheetModal';
+import { PauseMenuDialog } from '@/components/PauseMenuDialog';
 import type { QuizContext } from '@/hooks/useQuiz';
 
 interface Props {
@@ -44,6 +47,8 @@ export default function QuizView({ quiz }: Props) {
   const [bereichComplete, setBereichComplete] = useState<string | null>(null);
   const [remainingSeconds, setRemainingSeconds] = useState<number | undefined>();
   const [examAbgelaufen, setExamAbgelaufen] = useState(false);
+  const [cheatSheetOpen, setCheatSheetOpen] = useState(false);
+  const [pauseMenuOpen, setPauseMenuOpen] = useState(false);
 
   // Exam timer
   useEffect(() => {
@@ -141,7 +146,30 @@ export default function QuizView({ quiz }: Props) {
       checkBereichComplete,
       examAbgelaufen,
     ],
-  );
+   );
+
+  // Keyboard shortcuts
+  useKeyboardShortcuts({
+    onAnswer: handleAnswerClick,
+    onPrev: vorherigeFrage,
+    onNext: naechsteFrage,
+    onToggleFavorite: () => {
+      if (aktuelleFrage) {
+        toggleFavorite(aktuelleFrage.id);
+      }
+    },
+    // Space is a no-op in quiz mode (answer selection via number keys only)
+    onSpace: undefined,
+    onOpenCheatSheet: () => setCheatSheetOpen(true),
+    onEscape: () => {
+      if (cheatSheetOpen) {
+        setCheatSheetOpen(false);
+      } else {
+        setPauseMenuOpen(true);
+      }
+    },
+    enabled: quiz.isActive && !cheatSheetOpen && !pauseMenuOpen,
+  });
 
   if (!aktuelleFrage) return null;
 
@@ -256,8 +284,12 @@ export default function QuizView({ quiz }: Props) {
                 </Button>
               </div>
             </DialogContent>
-          </Dialog>
-        </div>
+           </Dialog>
+
+           {/* Keyboard shortcuts modals */}
+           <CheatSheetModal open={cheatSheetOpen} onOpenChange={setCheatSheetOpen} />
+           <PauseMenuDialog open={pauseMenuOpen} onOpenChange={setPauseMenuOpen} quiz={quiz} />
+         </div>
       </div>
     </TooltipProvider>
   );


### PR DESCRIPTION
Implements global keyboard shortcuts for quiz sessions as specified in issue #81.

**Features added:**
- // → select answer A/B/C
-  /  → navigate previous/next question
-  → reveals answer in flashcard mode; no-op in quiz mode (answer selection via numbers)
-  → toggle favorite on current question
-  → opens cheat sheet modal with all shortcuts
-  → opens pause menu (Resume, Neustart, Zur Startseite) when no other modal open; closes cheat sheet or any open modal otherwise

**Technical:**
- New  hook with global window listener, input-guard, switch-based dispatcher
- New  component listing shortcuts
- New  component for quick actions
- Integrated into  and 
- Unit + integration tests in 

**Sub-issues:** #124 (hook), #125 (QuizView), #126 (CheatSheetModal), #127 (FlashcardView), #128 (tests)

Closes #81.