### PR TITLE
feat(game-menu): keyboard navigation, focus management, and openTo (#140)

### DIFF
--- a/src/hooks/useGameMenu.ts
+++ b/src/hooks/useGameMenu.ts
@@ -7,6 +7,7 @@ interface GameMenuState {
   stack: MenuPageId[];
   direction: 'forward' | 'back';
   focusedIndex: number;
+  itemCount: number;
 }
 
 export function useGameMenu() {
@@ -15,6 +16,7 @@ export function useGameMenu() {
     stack: ['root'],
     direction: 'forward',
     focusedIndex: 0,
+    itemCount: 0,
   });
 
   const open = useCallback(() => {
@@ -60,6 +62,32 @@ export function useGameMenu() {
     });
   }, []);
 
+  const openTo = useCallback((page: MenuPageId) => {
+    setState(prev => ({
+      ...prev,
+      isOpen: true,
+      stack: [page],
+      direction: 'forward',
+      focusedIndex: 0,
+    }));
+  }, []);
+
+  const resetFocus = useCallback(() => {
+    setState(prev => ({ ...prev, focusedIndex: 0 }));
+  }, []);
+
+  const setFocusedIndex = useCallback((index: number) => {
+    setState(prev => ({ ...prev, focusedIndex: index }));
+  }, []);
+
+  const registerItemCount = useCallback((count: number) => {
+    setState(prev => ({
+      ...prev,
+      itemCount: count,
+      focusedIndex: Math.min(prev.focusedIndex, Math.max(0, count - 1)),
+    }));
+  }, []);
+
   const currentPage = state.stack[state.stack.length - 1];
 
   // Keyboard navigation
@@ -67,10 +95,41 @@ export function useGameMenu() {
     if (!state.isOpen) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        pop();
-        return;
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setState(prev => ({
+            ...prev,
+            focusedIndex: Math.min(prev.focusedIndex + 1, Math.max(0, prev.itemCount - 1)),
+          }));
+          return;
+        case 'ArrowUp':
+          e.preventDefault();
+          setState(prev => ({
+            ...prev,
+            focusedIndex: Math.max(prev.focusedIndex - 1, 0),
+          }));
+          return;
+        case 'Home':
+          e.preventDefault();
+          setState(prev => ({ ...prev, focusedIndex: 0 }));
+          return;
+        case 'End':
+          e.preventDefault();
+          setState(prev => ({
+            ...prev,
+            focusedIndex: Math.max(0, prev.itemCount - 1),
+          }));
+          return;
+        case 'Enter':
+        case ' ':
+          e.preventDefault();
+          // Caller is responsible for wiring the actual action
+          return;
+        case 'Escape':
+          e.preventDefault();
+          pop();
+          return;
       }
     };
 
@@ -83,7 +142,11 @@ export function useGameMenu() {
     currentPage,
     open,
     close,
+    openTo,
     push,
     pop,
+    resetFocus,
+    setFocusedIndex,
+    registerItemCount,
   };
 }


### PR DESCRIPTION
Closes #140

## Summary

Expands `useGameMenu` to support full keyboard navigation and focus management inside the menu.

### Changes

- **Modified** `src/hooks/useGameMenu.ts`:
  - Added `itemCount` to state and `registerItemCount(count)` method so the active page can tell the hook how many items it has
  - `focusedIndex` is now actively managed with bounds clamping
  - Exposed `setFocusedIndex`, `resetFocus()`, and `openTo(pageId)`
  - Expanded keyboard handler:
    - `ArrowDown` — increments `focusedIndex` (clamps at `itemCount - 1`)
    - `ArrowUp` — decrements `focusedIndex` (clamps at `0`)
    - `Home` — jumps to index `0`
    - `End` — jumps to `itemCount - 1`
    - `Enter` / `Space` — captured with `e.preventDefault()`; caller is responsible for wiring the actual action using `focusedIndex`
    - `Escape` — still triggers `pop()` (existing behavior)

### Checklist

- [x] `npm run lint` clean
- [x] `npm run test:run` all tests green (160 passed)
- [x] `npm run build` clean
- [x] Commit follows Conventional Commits
- [x] Issue referenced in commit and PR