### PR TITLE
feat(game-menu): productionize MenuPageRoot, MenuPageSettings & MenuItem (#142)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import { useCallback } from 'react';
 import { useQuiz } from '@/hooks/useQuiz';
-import { TopNavBar } from '@/components/TopNavBar';
+import { useGameMenu } from '@/hooks/useGameMenu';
+
+import { HUD } from '@/components/game-menu/HUD';
+import { GameMenuOverlay } from '@/components/game-menu/GameMenuOverlay';
 import { Spinner } from '@/components/ui/spinner';
 import StartView from '@/views/StartView';
 import QuizView from '@/views/QuizView';
@@ -11,6 +14,7 @@ import BrowseView from '@/views/BrowseView';
 
 export default function App() {
   const quiz = useQuiz();
+  const gameMenu = useGameMenu();
 
   const handleRetry = useCallback(() => {
     window.location.reload();
@@ -52,20 +56,28 @@ export default function App() {
   const isQuizActive = quiz.isActive;
   const currentView = quiz.view;
 
-  // Sidebar-Button-Sichtbarkeit
-  const showResumeOnStart = currentView === 'start' && isQuizActive;
-  const showResumeOnProgress = currentView === 'progress' && isQuizActive;
   const showProgressOnQuiz = currentView === 'quiz' && isQuizActive;
 
   return (
     <>
-      <TopNavBar
-        quiz={quiz}
+      <HUD
+        isActive={isQuizActive}
         onHome={() => quiz.goToView('start')}
-        onResumeQuiz={() => quiz.goToView('quiz')}
-        showResume={showResumeOnStart || showResumeOnProgress}
+        onMenuOpen={gameMenu.open}
         onShowProgress={() => quiz.goToView('progress')}
         showProgress={showProgressOnQuiz}
+        onStopQuiz={() => quiz.unterbrecheRun()}
+        runStatus={isQuizActive ? `${quiz.statistiken?.beantwortet ?? 0}/${quiz.statistiken?.gesamt ?? 0}` : undefined}
+      />
+
+      <GameMenuOverlay
+        isOpen={gameMenu.isOpen}
+        stack={gameMenu.stack}
+        currentPage={gameMenu.currentPage}
+        direction={gameMenu.direction}
+        onClose={gameMenu.close}
+        onPop={gameMenu.pop}
+        onPush={gameMenu.push}
       />
 
       {currentView === 'quiz' && isQuizActive && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ export default function App() {
         onClose={gameMenu.close}
         onPop={gameMenu.pop}
         onPush={gameMenu.push}
+        quiz={quiz}
       />
 
       {currentView === 'quiz' && isQuizActive && (

--- a/src/components/game-menu/GameMenuOverlay.tsx
+++ b/src/components/game-menu/GameMenuOverlay.tsx
@@ -89,16 +89,16 @@ export function GameMenuOverlay({
       // Legacy fallback for pages not yet fully migrated to config
       switch (page) {
         case 'root':
-          return <MenuPageRoot onPush={onPush} />;
+          return <MenuPageRoot onPush={onPush} onClose={onClose} quiz={quiz} />;
         case 'settings':
-          return <MenuPageSettings onPush={onPush} />;
+          return <MenuPageSettings onPush={onPush} quiz={quiz} />;
         case 'data':
           return <MenuPageData quiz={quiz} />;
         default:
-          return <MenuPageRoot onPush={onPush} />;
+          return <MenuPageRoot onPush={onPush} onClose={onClose} quiz={quiz} />;
       }
     },
-    [onPush, quiz]
+    [onPush, onClose, quiz]
   );
 
   const header = (

--- a/src/components/game-menu/GameMenuOverlay.tsx
+++ b/src/components/game-menu/GameMenuOverlay.tsx
@@ -1,9 +1,13 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
+import { Drawer as DrawerPrimitive } from 'vaul';
 import type { MenuPageId } from '@/hooks/useGameMenu';
 import type { QuizContext } from '@/hooks/useQuiz';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { MENU_PAGES } from './menuConfig';
 import { MenuPageRoot } from './MenuPageRoot';
 import { MenuPageSettings } from './MenuPageSettings';
 import { MenuPageData } from './MenuPageData';
+import { MenuPageList } from './MenuPageList';
 import { X, ChevronLeft } from 'lucide-react';
 
 interface GameMenuOverlayProps {
@@ -17,13 +21,8 @@ interface GameMenuOverlayProps {
   quiz: QuizContext;
 }
 
-const pageTitles: Record<MenuPageId, string> = {
-  root: 'Menü',
-  settings: 'Einstellungen',
-  navigation: 'Navigation',
-  'run-actions': 'Run-Aktionen',
-  data: 'Backup & Daten',
-};
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
 export function GameMenuOverlay({
   isOpen,
@@ -35,97 +34,173 @@ export function GameMenuOverlay({
   onPush,
   quiz,
 }: GameMenuOverlayProps) {
-  const overlayRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const lastFocusedRef = useRef<HTMLElement | null>(null);
   const isRoot = stack.length === 1;
 
+  const pageConfig = MENU_PAGES.find((p) => p.id === currentPage);
+  const title = pageConfig?.title ?? '';
+
+  // Store previously focused element when opening, restore on close
+  useEffect(() => {
+    if (isOpen) {
+      lastFocusedRef.current = document.activeElement as HTMLElement;
+    } else if (lastFocusedRef.current) {
+      lastFocusedRef.current.focus();
+      lastFocusedRef.current = null;
+    }
+  }, [isOpen]);
+
+  // Focus first focusable item when opening or changing page
   useEffect(() => {
     if (!isOpen) return;
+    const timer = setTimeout(() => {
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusable = panel.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+      focusable?.focus();
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [isOpen, currentPage]);
+
+  // Body scroll lock on desktop (vaul handles mobile)
+  useEffect(() => {
+    if (isMobile || !isOpen) return;
     document.body.style.overflow = 'hidden';
     return () => {
       document.body.style.overflow = '';
     };
-  }, [isOpen]);
+  }, [isOpen, isMobile]);
+
+  const renderPage = useCallback(
+    (page: MenuPageId) => {
+      const config = MENU_PAGES.find((p) => p.id === page);
+
+      if (config?.customComponent) {
+        const Component = config.customComponent;
+        return <Component />;
+      }
+
+      if (config?.sections) {
+        return <MenuPageList sections={config.sections} />;
+      }
+
+      // Legacy fallback for pages not yet fully migrated to config
+      switch (page) {
+        case 'root':
+          return <MenuPageRoot onPush={onPush} />;
+        case 'settings':
+          return <MenuPageSettings onPush={onPush} />;
+        case 'data':
+          return <MenuPageData quiz={quiz} />;
+        default:
+          return <MenuPageRoot onPush={onPush} />;
+      }
+    },
+    [onPush, quiz]
+  );
+
+  const header = (
+    <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200/60 dark:border-slate-700/60 shrink-0">
+      <button
+        onClick={isRoot ? onClose : onPop}
+        className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+        aria-label={isRoot ? 'Schließen' : 'Zurück'}
+      >
+        {isRoot ? (
+          <X className="w-5 h-5 text-slate-500 dark:text-slate-400" />
+        ) : (
+          <ChevronLeft className="w-5 h-5 text-slate-500 dark:text-slate-400" />
+        )}
+      </button>
+
+      <h2 className="text-[17px] font-semibold text-slate-900 dark:text-white">
+        {title}
+      </h2>
+
+      <div className="w-8" />
+    </div>
+  );
+
+  const swipeHandle = (
+    <div className="flex justify-center pt-2 pb-1 shrink-0">
+      <div className="w-10 h-1 rounded-full bg-slate-300/50 dark:bg-slate-600/50" />
+    </div>
+  );
+
+  const pageContent = (
+    <div className="relative flex-1 overflow-y-auto">
+      <div
+        key={stack.join('-')}
+        className={`
+          animate-in
+          ${direction === 'forward' ? 'slide-in-from-right-full' : 'slide-in-from-left-full'}
+          duration-300 ease-out
+        `}
+      >
+        {renderPage(currentPage)}
+      </div>
+    </div>
+  );
 
   if (!isOpen) return null;
 
-  const renderPage = (page: MenuPageId) => {
-    switch (page) {
-      case 'root':
-        return <MenuPageRoot onPush={onPush} />;
-      case 'settings':
-        return <MenuPageSettings onPush={onPush} />;
-      case 'data':
-        return <MenuPageData quiz={quiz} />;
-      default:
-        return <MenuPageRoot onPush={onPush} />;
-    }
-  };
+  if (isMobile) {
+    return (
+      <DrawerPrimitive.Root
+        open={isOpen}
+        onOpenChange={(open) => {
+          if (!open) onClose();
+        }}
+        snapPoints={[0.5, 0.85]}
+        dismissible
+      >
+        <DrawerPrimitive.Portal>
+          <DrawerPrimitive.Overlay className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm animate-in fade-in duration-200" />
+          <DrawerPrimitive.Content
+            ref={panelRef}
+            className="fixed bottom-0 left-0 right-0 z-50 flex flex-col rounded-t-3xl bg-white dark:bg-slate-900 shadow-2xl shadow-black/20 max-h-[85vh]"
+            aria-modal="true"
+            role="dialog"
+            aria-label={title}
+          >
+            {swipeHandle}
+            {header}
+            {pageContent}
+          </DrawerPrimitive.Content>
+        </DrawerPrimitive.Portal>
+      </DrawerPrimitive.Root>
+    );
+  }
 
   return (
-    <div
-      ref={overlayRef}
-      className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center"
-      onClick={(e) => {
-        if (e.target === overlayRef.current) onClose();
-      }}
-    >
+    <div className="fixed inset-0 z-[60] flex items-center justify-center">
       {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm animate-in fade-in duration-200" />
-
-      {/* Menu Panel — bottom sheet on mobile, centered on desktop */}
       <div
-        className={`
-          relative w-full sm:max-w-md sm:max-h-[80vh]
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm animate-in fade-in duration-200"
+        onClick={onClose}
+      />
+
+      {/* Menu Panel */}
+      <div
+        ref={panelRef}
+        className="
+          relative w-full max-w-md max-h-[80vh]
           bg-white dark:bg-slate-900
-          rounded-t-3xl sm:rounded-3xl
+          rounded-3xl
           shadow-2xl shadow-black/20
           overflow-hidden
-          animate-in slide-in-from-bottom-8 sm:slide-in-from-bottom-0
-          fade-in zoom-in-95
+          animate-in fade-in zoom-in-95
           duration-300 ease-out
           flex flex-col
-        `}
-        style={{ maxHeight: '85vh' }}
+        "
+        aria-modal="true"
+        role="dialog"
+        aria-label={title}
       >
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200/60 dark:border-slate-700/60">
-          <button
-            onClick={isRoot ? onClose : onPop}
-            className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
-            aria-label={isRoot ? 'Schließen' : 'Zurück'}
-          >
-            {isRoot ? (
-              <X className="w-5 h-5 text-slate-500 dark:text-slate-400" />
-            ) : (
-              <ChevronLeft className="w-5 h-5 text-slate-500 dark:text-slate-400" />
-            )}
-          </button>
-
-          <h2 className="text-[17px] font-semibold text-slate-900 dark:text-white">
-            {pageTitles[currentPage]}
-          </h2>
-
-          <div className="w-8" /> {/* spacer for centering */}
-        </div>
-
-        {/* Swipe handle (mobile) */}
-        <div className="sm:hidden flex justify-center pt-2 pb-1">
-          <div className="w-10 h-1 rounded-full bg-slate-300/50 dark:bg-slate-600/50" />
-        </div>
-
-        {/* Page Content with iOS slide transition */}
-        <div className="relative flex-1 overflow-y-auto">
-          <div
-            key={stack.join('-')}
-            className={`
-              animate-in
-              ${direction === 'forward' ? 'slide-in-from-right-full' : 'slide-in-from-left-full'}
-              duration-300 ease-out
-            `}
-          >
-            {renderPage(currentPage)}
-          </div>
-        </div>
+        {header}
+        {pageContent}
       </div>
     </div>
   );

--- a/src/components/game-menu/GameMenuOverlay.tsx
+++ b/src/components/game-menu/GameMenuOverlay.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef } from 'react';
+import type { MenuPageId } from '@/hooks/useGameMenu';
+import { MenuPageRoot } from './MenuPageRoot';
+import { MenuPageSettings } from './MenuPageSettings';
+import { X, ChevronLeft } from 'lucide-react';
+
+interface GameMenuOverlayProps {
+  isOpen: boolean;
+  stack: MenuPageId[];
+  currentPage: MenuPageId;
+  direction: 'forward' | 'back';
+  onClose: () => void;
+  onPop: () => void;
+  onPush: (page: MenuPageId) => void;
+}
+
+const pageTitles: Record<MenuPageId, string> = {
+  root: 'Menü',
+  settings: 'Einstellungen',
+  navigation: 'Navigation',
+  'run-actions': 'Run-Aktionen',
+};
+
+export function GameMenuOverlay({
+  isOpen,
+  stack,
+  currentPage,
+  direction,
+  onClose,
+  onPop,
+  onPush,
+}: GameMenuOverlayProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const isRoot = stack.length === 1;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const renderPage = (page: MenuPageId) => {
+    switch (page) {
+      case 'root':
+        return <MenuPageRoot onPush={onPush} />;
+      case 'settings':
+        return <MenuPageSettings />;
+      default:
+        return <MenuPageRoot onPush={onPush} />;
+    }
+  };
+
+  return (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center"
+      onClick={(e) => {
+        if (e.target === overlayRef.current) onClose();
+      }}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm animate-in fade-in duration-200" />
+
+      {/* Menu Panel — bottom sheet on mobile, centered on desktop */}
+      <div
+        className={`
+          relative w-full sm:max-w-md sm:max-h-[80vh]
+          bg-white dark:bg-slate-900
+          rounded-t-3xl sm:rounded-3xl
+          shadow-2xl shadow-black/20
+          overflow-hidden
+          animate-in slide-in-from-bottom-8 sm:slide-in-from-bottom-0
+          fade-in zoom-in-95
+          duration-300 ease-out
+          flex flex-col
+        `}
+        style={{ maxHeight: '85vh' }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200/60 dark:border-slate-700/60">
+          <button
+            onClick={isRoot ? onClose : onPop}
+            className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+            aria-label={isRoot ? 'Schließen' : 'Zurück'}
+          >
+            {isRoot ? (
+              <X className="w-5 h-5 text-slate-500 dark:text-slate-400" />
+            ) : (
+              <ChevronLeft className="w-5 h-5 text-slate-500 dark:text-slate-400" />
+            )}
+          </button>
+
+          <h2 className="text-[17px] font-semibold text-slate-900 dark:text-white">
+            {pageTitles[currentPage]}
+          </h2>
+
+          <div className="w-8" /> {/* spacer for centering */}
+        </div>
+
+        {/* Swipe handle (mobile) */}
+        <div className="sm:hidden flex justify-center pt-2 pb-1">
+          <div className="w-10 h-1 rounded-full bg-slate-300/50 dark:bg-slate-600/50" />
+        </div>
+
+        {/* Page Content with iOS slide transition */}
+        <div className="relative flex-1 overflow-y-auto">
+          <div
+            key={stack.join('-')}
+            className={`
+              animate-in
+              ${direction === 'forward' ? 'slide-in-from-right-full' : 'slide-in-from-left-full'}
+              duration-300 ease-out
+            `}
+          >
+            {renderPage(currentPage)}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/game-menu/GameMenuOverlay.tsx
+++ b/src/components/game-menu/GameMenuOverlay.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from 'react';
 import type { MenuPageId } from '@/hooks/useGameMenu';
+import type { QuizContext } from '@/hooks/useQuiz';
 import { MenuPageRoot } from './MenuPageRoot';
 import { MenuPageSettings } from './MenuPageSettings';
+import { MenuPageData } from './MenuPageData';
 import { X, ChevronLeft } from 'lucide-react';
 
 interface GameMenuOverlayProps {
@@ -12,6 +14,7 @@ interface GameMenuOverlayProps {
   onClose: () => void;
   onPop: () => void;
   onPush: (page: MenuPageId) => void;
+  quiz: QuizContext;
 }
 
 const pageTitles: Record<MenuPageId, string> = {
@@ -30,6 +33,7 @@ export function GameMenuOverlay({
   onClose,
   onPop,
   onPush,
+  quiz,
 }: GameMenuOverlayProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
   const isRoot = stack.length === 1;
@@ -49,7 +53,9 @@ export function GameMenuOverlay({
       case 'root':
         return <MenuPageRoot onPush={onPush} />;
       case 'settings':
-        return <MenuPageSettings />;
+        return <MenuPageSettings onPush={onPush} />;
+      case 'data':
+        return <MenuPageData quiz={quiz} />;
       default:
         return <MenuPageRoot onPush={onPush} />;
     }

--- a/src/components/game-menu/GameMenuOverlay.tsx
+++ b/src/components/game-menu/GameMenuOverlay.tsx
@@ -19,6 +19,7 @@ const pageTitles: Record<MenuPageId, string> = {
   settings: 'Einstellungen',
   navigation: 'Navigation',
   'run-actions': 'Run-Aktionen',
+  data: 'Backup & Daten',
 };
 
 export function GameMenuOverlay({

--- a/src/components/game-menu/HUD.tsx
+++ b/src/components/game-menu/HUD.tsx
@@ -1,0 +1,134 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { Home, Menu, BarChart3, Square } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface HUDProps {
+  isActive: boolean;
+  onHome: () => void;
+  onMenuOpen: () => void;
+  onShowProgress?: () => void;
+  showProgress?: boolean;
+  onStopQuiz?: () => void;
+  runStatus?: string;
+}
+
+export function HUD({
+  isActive,
+  onHome,
+  onMenuOpen,
+  onShowProgress,
+  showProgress,
+  onStopQuiz,
+  runStatus,
+}: HUDProps) {
+  const [hidden, setHidden] = useState(false);
+  const touchStartY = useRef<number | null>(null);
+  const hudRef = useRef<HTMLDivElement>(null);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartY.current = e.touches[0].clientY;
+  }, []);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (touchStartY.current === null) return;
+    const diff = e.touches[0].clientY - touchStartY.current;
+    if (diff < -40 && !hidden) {
+      setHidden(true);
+      touchStartY.current = null;
+    } else if (diff > 40 && hidden) {
+      setHidden(false);
+      touchStartY.current = null;
+    }
+  }, [hidden]);
+
+  // Keyboard: H to toggle HUD
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'h' || e.key === 'H') {
+        setHidden(prev => !prev);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  return (
+    <>
+      {/* Hidden indicator — tap or swipe up to show */}
+      {hidden && (
+        <div
+          className="fixed top-0 left-0 right-0 z-40 flex justify-center pt-1"
+          onClick={() => setHidden(false)}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+        >
+          <div className="w-10 h-1 rounded-full bg-slate-300/60 dark:bg-slate-600/60 cursor-pointer hover:bg-slate-400/60 transition-colors" />
+        </div>
+      )}
+
+      {/* HUD Bar */}
+      <div
+        ref={hudRef}
+        className={`
+          fixed top-3 left-1/2 -translate-x-1/2 z-50
+          transition-transform duration-300 ease-out
+          ${hidden ? '-translate-y-[calc(100%+24px)]' : 'translate-y-0'}
+        `}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+      >
+        <div className="flex items-center gap-1.5 bg-white/90 backdrop-blur-xl border border-slate-200/60 rounded-2xl px-2.5 py-1.5 shadow-lg shadow-black/10 dark:bg-slate-900/90 dark:border-slate-700/60 dark:shadow-black/20">
+          <Button
+            onClick={onHome}
+            variant="ghost"
+            size="icon"
+            aria-label="Zur Startseite"
+            className="w-8 h-8 rounded-xl bg-slate-100/80 text-teal-500 hover:bg-slate-200 hover:text-teal-600 dark:bg-slate-800/80 dark:text-teal-400 dark:hover:bg-slate-700"
+          >
+            <Home className="w-4 h-4" />
+          </Button>
+
+          <Button
+            onClick={onMenuOpen}
+            variant="ghost"
+            size="icon"
+            aria-label="Menü öffnen"
+            className="w-9 h-9 rounded-xl bg-slate-100/80 text-slate-600 hover:bg-slate-200 hover:text-slate-900 dark:bg-slate-800/80 dark:text-slate-300 dark:hover:bg-slate-700"
+          >
+            <Menu className="w-4 h-4" />
+          </Button>
+
+          {showProgress && onShowProgress && (
+            <Button
+              onClick={onShowProgress}
+              variant="ghost"
+              size="icon"
+              aria-label="Fortschritt"
+              className="w-8 h-8 rounded-xl bg-slate-100/80 text-slate-600 hover:bg-slate-200 dark:bg-slate-800/80 dark:text-slate-300 dark:hover:bg-slate-700"
+            >
+              <BarChart3 className="w-4 h-4" />
+            </Button>
+          )}
+
+          {isActive && onStopQuiz && (
+            <Button
+              onClick={onStopQuiz}
+              variant="ghost"
+              size="icon"
+              aria-label="Quiz beenden"
+              className="w-8 h-8 rounded-xl bg-slate-100/80 text-red-500 hover:bg-red-100 hover:text-red-600 dark:bg-slate-800/80 dark:text-red-400 dark:hover:bg-red-900/50"
+            >
+              <Square className="w-3.5 h-3.5 fill-current" />
+            </Button>
+          )}
+
+          {runStatus && (
+            <div className="px-2 py-0.5 rounded-lg bg-teal-100/80 text-teal-700 text-[11px] font-semibold dark:bg-teal-900/50 dark:text-teal-400">
+              {runStatus}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/game-menu/MenuItem.tsx
+++ b/src/components/game-menu/MenuItem.tsx
@@ -1,0 +1,51 @@
+import { ChevronRight } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+interface MenuItemProps {
+  icon?: ReactNode;
+  label: string;
+  detail?: string;
+  onClick?: () => void;
+  destructive?: boolean;
+  disabled?: boolean;
+  isFocused?: boolean;
+}
+
+export function MenuItem({
+  icon,
+  label,
+  detail,
+  onClick,
+  destructive,
+  disabled,
+  isFocused,
+}: MenuItemProps) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`
+        w-full flex items-center gap-3 px-4 py-3 text-left
+        transition-colors duration-150
+        focus:outline-none focus-visible:bg-accent
+        active:scale-[0.98]
+        ${isFocused ? 'bg-accent' : 'bg-transparent hover:bg-accent/50'}
+        ${disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'}
+        ${destructive ? 'text-red-500 dark:text-red-400' : 'text-foreground'}
+      `}
+    >
+      {icon && (
+        <span className={`flex-shrink-0 ${destructive ? 'text-red-500 dark:text-red-400' : 'text-muted-foreground'}`}>
+          {icon}
+        </span>
+      )}
+      <span className="flex-1 text-[15px] font-medium leading-tight">{label}</span>
+      {detail && (
+        <span className="text-sm text-muted-foreground">{detail}</span>
+      )}
+      {onClick && (
+        <ChevronRight className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+      )}
+    </button>
+  );
+}

--- a/src/components/game-menu/MenuItem.tsx
+++ b/src/components/game-menu/MenuItem.tsx
@@ -9,6 +9,7 @@ interface MenuItemProps {
   destructive?: boolean;
   disabled?: boolean;
   isFocused?: boolean;
+  'aria-label'?: string;
 }
 
 export function MenuItem({
@@ -19,15 +20,18 @@ export function MenuItem({
   destructive,
   disabled,
   isFocused,
+  'aria-label': ariaLabel,
 }: MenuItemProps) {
   return (
     <button
       onClick={onClick}
       disabled={disabled}
+      tabIndex={isFocused === true ? 0 : isFocused === false ? -1 : undefined}
+      aria-label={ariaLabel}
       className={`
         w-full flex items-center gap-3 px-4 py-3 text-left
         transition-colors duration-150
-        focus:outline-none focus-visible:bg-accent
+        focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:outline-none
         active:scale-[0.98]
         ${isFocused ? 'bg-accent' : 'bg-transparent hover:bg-accent/50'}
         ${disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'}

--- a/src/components/game-menu/MenuPageData.tsx
+++ b/src/components/game-menu/MenuPageData.tsx
@@ -1,0 +1,233 @@
+import { useRef, useState } from 'react';
+import { FileJson, Table, Database, Upload, RotateCcw, Download, Trash2, Bell } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import type { QuizContext } from '@/hooks/useQuiz';
+import { buildCsv } from '@/utils/csvExport';
+import { MetaProgressionSchema } from '@/utils/quizLoader';
+
+interface MenuPageDataProps {
+  quiz: QuizContext;
+}
+
+export function MenuPageData({ quiz }: MenuPageDataProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const backupInputRef = useRef<HTMLInputElement>(null);
+  const [expJson, setExpJson] = useState(false);
+  const [expCsv, setExpCsv] = useState(false);
+  const [expBackup, setExpBackup] = useState(false);
+
+  return (
+    <div className="py-2 space-y-6 px-4">
+      {/* Export Section */}
+      <section>
+        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
+          Export
+        </h3>
+        <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
+          <div className="flex items-center space-x-2 px-4 py-3">
+            <Checkbox
+              id="exp-json-data"
+              checked={expJson}
+              onCheckedChange={(v) => setExpJson(v === true)}
+            />
+            <Label htmlFor="exp-json-data" className="flex-1 cursor-pointer flex items-center gap-2 text-[15px]">
+              <FileJson className="w-4 h-4 text-slate-400" />
+              Progress (JSON)
+            </Label>
+          </div>
+          <div className="flex items-center space-x-2 px-4 py-3">
+            <Checkbox
+              id="exp-csv-data"
+              checked={expCsv}
+              onCheckedChange={(v) => setExpCsv(v === true)}
+            />
+            <Label htmlFor="exp-csv-data" className="flex-1 cursor-pointer flex items-center gap-2 text-[15px]">
+              <Table className="w-4 h-4 text-slate-400" />
+              Stats (CSV)
+            </Label>
+          </div>
+          <div className="flex items-center space-x-2 px-4 py-3">
+            <Checkbox
+              id="exp-backup-data"
+              checked={expBackup}
+              onCheckedChange={(v) => setExpBackup(v === true)}
+            />
+            <Label htmlFor="exp-backup-data" className="flex-1 cursor-pointer flex items-center gap-2 text-[15px]">
+              <Database className="w-4 h-4 text-slate-400" />
+              Full Backup
+            </Label>
+          </div>
+          <div className="px-4 pb-3">
+            <Button
+              size="sm"
+              className="w-full"
+              disabled={!expJson && !expCsv && !expBackup}
+              onClick={() => {
+                if (expJson) {
+                  const data = quiz.metaProgress;
+                  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+                  const url = URL.createObjectURL(blob);
+                  const a = document.createElement('a');
+                  a.href = url;
+                  a.download = `fishermans-quiz-meta-${new Date().toISOString().split('T')[0]}.json`;
+                  a.click();
+                  URL.revokeObjectURL(url);
+                }
+                if (expCsv) {
+                  const rows = [
+                    ['Frage-ID', 'Bereich', 'Versuche', 'Serie', 'Letztes Ergebnis', 'Erst gesehen', 'Zuletzt'],
+                    ...Object.entries(quiz.metaProgress.fragen).map(([id, m]) => [
+                      id,
+                      quiz.quizMeta?.fragenIndex?.[id] ?? '',
+                      String(m.attempts),
+                      String(m.correctStreak),
+                      m.lastResult ?? '',
+                      m.firstSeen,
+                      m.lastAttempt,
+                    ]),
+                  ];
+                  const csv = buildCsv(rows);
+                  const blob = new Blob([csv], { type: 'text/csv' });
+                  const url = URL.createObjectURL(blob);
+                  const a = document.createElement('a');
+                  a.href = url;
+                  a.download = `fishermans-quiz-stats-${new Date().toISOString().split('T')[0]}.csv`;
+                  a.click();
+                  URL.revokeObjectURL(url);
+                }
+                if (expBackup) {
+                  quiz.exportFullBackup?.();
+                }
+              }}
+            >
+              <Download className="w-4 h-4 mr-2" />
+              Export
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* Import Section */}
+      <section>
+        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
+          Import
+        </h3>
+        <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (!file) return;
+              const reader = new FileReader();
+              reader.onload = (ev) => {
+                try {
+                  const data = JSON.parse(ev.target?.result as string);
+                  const parsed = MetaProgressionSchema.safeParse(data);
+                  if (parsed.success) {
+                    if (confirm('Import progress data? This will overwrite current progress.')) {
+                      quiz.importMetaProgression?.(parsed.data);
+                    }
+                  } else {
+                    console.error('[Import] Validation failed:', parsed.error.format());
+                    alert('Invalid file format. The file does not contain valid progress data.');
+                  }
+                } catch {
+                  alert('Error reading file.');
+                }
+                if (fileInputRef.current) fileInputRef.current.value = '';
+              };
+              reader.readAsText(file);
+            }}
+          />
+          <input
+            ref={backupInputRef}
+            type="file"
+            accept=".json"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (!file) return;
+              const reader = new FileReader();
+              reader.onload = (ev) => {
+                try {
+                  const data = JSON.parse(ev.target?.result as string);
+                  if (confirm('Restore full backup? This will overwrite ALL data and reload the page.')) {
+                    const ok = quiz.importFullBackup?.(data);
+                    if (ok === false) {
+                      alert('Invalid backup format.');
+                    }
+                  }
+                } catch {
+                  alert('Error reading file.');
+                }
+                if (backupInputRef.current) backupInputRef.current.value = '';
+              };
+              reader.readAsText(file);
+            }}
+          />
+          <div className="px-4 py-3 grid grid-cols-2 gap-3">
+            <Button variant="outline" size="sm" className="h-8" onClick={() => fileInputRef.current?.click()}>
+              <Upload className="w-4 h-4 mr-2" />
+              Progress
+            </Button>
+            <Button variant="outline" size="sm" className="h-8" onClick={() => backupInputRef.current?.click()}>
+              <RotateCcw className="w-4 h-4 mr-2" />
+              Full Restore
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* Danger Zone */}
+      <section>
+        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
+          Danger Zone
+        </h3>
+        <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start px-4 py-3 h-auto text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-500/10"
+            onClick={() => {
+              if (confirm('Delete all data? This cannot be undone.')) {
+                quiz.resetMetaProgression();
+                quiz.resetSRS?.();
+                quiz.resetFavorites?.();
+                quiz.resetNotes?.();
+                quiz.clearHistory?.();
+              }
+            }}
+          >
+            <Trash2 className="w-4 h-4 mr-2" />
+            Alle Daten löschen
+          </Button>
+        </div>
+      </section>
+
+      {/* Backup Reminder */}
+      <section className="px-4">
+        <button
+          onClick={() => quiz.setBackupReminderEnabled?.(!quiz.backupReminderEnabled)}
+          aria-pressed={quiz.backupReminderEnabled}
+          className={`w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm font-medium transition-colors border ${
+            quiz.backupReminderEnabled
+              ? 'bg-teal-50 text-teal-600 border-teal-300/50 dark:bg-teal-500/10 dark:text-teal-400 dark:border-teal-500/30'
+              : 'text-slate-500 hover:text-slate-700 border-transparent dark:text-slate-400 dark:hover:text-slate-300'
+          }`}
+        >
+          <span className="flex items-center gap-2">
+            <Bell className={`w-4 h-4 ${quiz.backupReminderEnabled ? 'fill-current' : ''}`} />
+            Backup reminder
+          </span>
+          <span className="text-xs">{quiz.backupReminderEnabled ? 'on' : 'off'}</span>
+        </button>
+      </section>
+    </div>
+   );
+ }
+

--- a/src/components/game-menu/MenuPageList.tsx
+++ b/src/components/game-menu/MenuPageList.tsx
@@ -1,0 +1,38 @@
+import { MenuItem } from './MenuItem';
+import type { MenuSectionConfig } from './menuConfig';
+
+interface MenuPageListProps {
+  sections?: MenuSectionConfig[];
+}
+
+export function MenuPageList({ sections }: MenuPageListProps) {
+  if (!sections || sections.length === 0) return null;
+
+  return (
+    <div className="py-2 space-y-6 px-4">
+      {sections.map((section, sectionIndex) => (
+        <section key={sectionIndex}>
+          {section.title && (
+            <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
+              {section.title}
+            </h3>
+          )}
+          <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
+            {section.items.map((item) => {
+              const detail = typeof item.detail === 'string' ? item.detail : undefined;
+              return (
+                <MenuItem
+                  key={item.id}
+                  icon={<item.icon className="w-5 h-5" />}
+                  label={item.label}
+                  detail={detail}
+                  destructive={item.destructive}
+                />
+              );
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/components/game-menu/MenuPageRoot.tsx
+++ b/src/components/game-menu/MenuPageRoot.tsx
@@ -1,0 +1,68 @@
+import { Play, Settings, Search, History, BarChart3, LogOut, Timer } from 'lucide-react';
+import { MenuItem } from './MenuItem';
+import type { MenuPageId } from '@/hooks/useGameMenu';
+
+interface MenuPageRootProps {
+  onPush: (page: MenuPageId) => void;
+}
+
+export function MenuPageRoot({ onPush }: MenuPageRootProps) {
+  return (
+    <div className="py-2">
+      {/* Primary Actions */}
+      <div className="px-4 pb-3">
+        <button className="w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-teal-500 text-white font-semibold text-[15px] hover:bg-teal-600 active:scale-[0.98] transition-all">
+          <Play className="w-5 h-5" />
+          Quiz fortsetzen
+        </button>
+      </div>
+
+      {/* Menu Sections */}
+      <div className="space-y-6 px-4">
+        <section>
+          <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
+            Modus
+          </h3>
+          <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden">
+            <MenuItem icon={<Timer className="w-5 h-5" />} label="Arcade" detail="Aktiv" />
+          </div>
+        </section>
+
+        <section>
+          <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
+            Allgemein
+          </h3>
+          <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
+            <MenuItem
+              icon={<Settings className="w-5 h-5" />}
+              label="Einstellungen"
+              onClick={() => onPush('settings')}
+            />
+            <MenuItem
+              icon={<Search className="w-5 h-5" />}
+              label="Fragenkatalog"
+            />
+            <MenuItem
+              icon={<History className="w-5 h-5" />}
+              label="Session-Verlauf"
+            />
+            <MenuItem
+              icon={<BarChart3 className="w-5 h-5" />}
+              label="Statistiken"
+            />
+          </div>
+        </section>
+
+        <section>
+          <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden">
+            <MenuItem
+              icon={<LogOut className="w-5 h-5" />}
+              label="Quiz beenden"
+              destructive
+            />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/game-menu/MenuPageRoot.tsx
+++ b/src/components/game-menu/MenuPageRoot.tsx
@@ -1,68 +1,162 @@
-import { Play, Settings, Search, History, BarChart3, LogOut, Timer } from 'lucide-react';
+import { useState, useMemo } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { MENU_PAGES, type MenuContext, type MenuItemConfig, type MenuPageId } from './menuConfig';
 import { MenuItem } from './MenuItem';
-import type { MenuPageId } from '@/hooks/useGameMenu';
+import type { QuizContext } from '@/hooks/useQuiz';
+import type { AppView } from '@/types/quiz';
 
 interface MenuPageRootProps {
   onPush: (page: MenuPageId) => void;
+  onClose: () => void;
+  quiz: QuizContext;
 }
 
-export function MenuPageRoot({ onPush }: MenuPageRootProps) {
+export function MenuPageRoot({ onPush, onClose, quiz }: MenuPageRootProps) {
+  const [showExitDialog, setShowExitDialog] = useState(false);
+
+  const context = useMemo<MenuContext>(
+    () => ({
+      isQuizActive: quiz.isActive,
+      gameMode: quiz.gameMode,
+      theme: 'system',
+      currentView: quiz.view,
+      historyCount: quiz.historyEntries.length,
+      runStatus: quiz.isActive
+        ? `${quiz.statistiken?.beantwortet ?? 0}/${quiz.statistiken?.gesamt ?? 0}`
+        : undefined,
+    }),
+    [quiz]
+  );
+
+  const pageConfig = MENU_PAGES.find((p) => p.id === 'root');
+  if (!pageConfig) return null;
+
+  const handleContinueQuiz = () => {
+    if (quiz.isActive) {
+      onClose();
+    }
+  };
+
+  const handleExitQuiz = () => {
+    setShowExitDialog(true);
+  };
+
+  const confirmExitQuiz = () => {
+    setShowExitDialog(false);
+    quiz.unterbrecheRun();
+    onClose();
+  };
+
+  const handleItemClick = (item: MenuItemConfig) => {
+    if (item.action === 'navigate' && item.target) {
+      onPush(item.target as MenuPageId);
+    } else if (item.action === 'view' && item.target) {
+      quiz.goToView(item.target as AppView);
+      onClose();
+    } else if (item.action === 'action' && item.target) {
+      if (item.target === 'continue-quiz') {
+        handleContinueQuiz();
+      } else if (item.target === 'exit-quiz') {
+        handleExitQuiz();
+      }
+    }
+  };
+
+  const getDetail = (item: MenuItemConfig): string | undefined => {
+    if (!item.detail) return undefined;
+    return typeof item.detail === 'function' ? item.detail(context) : item.detail;
+  };
+
+  const isItemVisible = (item: MenuItemConfig): boolean => {
+    if (!item.condition) return true;
+    return item.condition(context);
+  };
+
   return (
     <div className="py-2">
-      {/* Primary Actions */}
-      <div className="px-4 pb-3">
-        <button className="w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-teal-500 text-white font-semibold text-[15px] hover:bg-teal-600 active:scale-[0.98] transition-all">
-          <Play className="w-5 h-5" />
-          Quiz fortsetzen
-        </button>
-      </div>
+      {pageConfig.sections?.map((section, sectionIndex) => {
+        const visibleItems = section.items.filter(isItemVisible);
+        if (visibleItems.length === 0) return null;
 
-      {/* Menu Sections */}
-      <div className="space-y-6 px-4">
-        <section>
-          <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
-            Modus
-          </h3>
-          <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden">
-            <MenuItem icon={<Timer className="w-5 h-5" />} label="Arcade" detail="Aktiv" />
-          </div>
-        </section>
+        const isPrimaryCtaSection =
+          sectionIndex === 0 &&
+          visibleItems.length === 1 &&
+          visibleItems[0].id === 'continue-quiz';
 
-        <section>
-          <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
-            Allgemein
-          </h3>
-          <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
-            <MenuItem
-              icon={<Settings className="w-5 h-5" />}
-              label="Einstellungen"
-              onClick={() => onPush('settings')}
-            />
-            <MenuItem
-              icon={<Search className="w-5 h-5" />}
-              label="Fragenkatalog"
-            />
-            <MenuItem
-              icon={<History className="w-5 h-5" />}
-              label="Session-Verlauf"
-            />
-            <MenuItem
-              icon={<BarChart3 className="w-5 h-5" />}
-              label="Statistiken"
-            />
-          </div>
-        </section>
+        if (isPrimaryCtaSection) {
+          const item = visibleItems[0];
+          return (
+            <div key={sectionIndex} className="px-4 pb-3">
+              <button
+                onClick={() => handleItemClick(item)}
+                disabled={!quiz.isActive}
+                className="w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-teal-500 text-white font-semibold text-[15px] hover:bg-teal-600 active:scale-[0.98] transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <item.icon className="w-5 h-5" />
+                {item.label}
+              </button>
+            </div>
+          );
+        }
 
-        <section>
-          <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden">
-            <MenuItem
-              icon={<LogOut className="w-5 h-5" />}
-              label="Quiz beenden"
-              destructive
-            />
-          </div>
-        </section>
-      </div>
+        return (
+          <section key={sectionIndex} className={sectionIndex > 0 ? 'mt-6' : ''}>
+            {section.title && (
+              <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
+                {section.title}
+              </h3>
+            )}
+            <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
+              {visibleItems.map((item) => (
+                <MenuItem
+                  key={item.id}
+                  icon={<item.icon className="w-5 h-5" />}
+                  label={item.label}
+                  detail={getDetail(item)}
+                  onClick={() => handleItemClick(item)}
+                  destructive={item.destructive}
+                />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+
+      <AlertDialog open={showExitDialog} onOpenChange={setShowExitDialog}>
+        <AlertDialogContent className="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-700">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-slate-900 dark:text-white">
+              Quiz beenden?
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-slate-500 dark:text-slate-400">
+              Meta-Fortschritt bleibt erhalten.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              onClick={() => setShowExitDialog(false)}
+              className="border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+            >
+              Abbrechen
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={confirmExitQuiz}
+              className="bg-red-600 hover:bg-red-700 text-white"
+            >
+              Beenden
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/components/game-menu/MenuPageSettings.tsx
+++ b/src/components/game-menu/MenuPageSettings.tsx
@@ -1,45 +1,93 @@
-import { Sun, Moon, Monitor, Zap, Shield, Timer, Download, Upload, Trash2 } from 'lucide-react';
+import { useMemo } from 'react';
+import { useTheme } from 'next-themes';
+import { MENU_PAGES, type MenuContext, type MenuItemConfig, type MenuPageId } from './menuConfig';
 import { MenuItem } from './MenuItem';
-import type { MenuPageId } from './menuConfig';
+import type { QuizContext } from '@/hooks/useQuiz';
+import type { GameMode } from '@/types/quiz';
 
-export function MenuPageSettings({ onPush }: { onPush: (page: MenuPageId) => void }) {
+interface MenuPageSettingsProps {
+  onPush: (page: MenuPageId) => void;
+  quiz: QuizContext;
+}
+
+export function MenuPageSettings({ onPush, quiz }: MenuPageSettingsProps) {
+  const { theme, setTheme } = useTheme();
+
+  const context = useMemo<MenuContext>(
+    () => ({
+      isQuizActive: quiz.isActive,
+      gameMode: quiz.gameMode,
+      theme: (theme as 'light' | 'dark' | 'system') ?? 'system',
+      currentView: quiz.view,
+      historyCount: quiz.historyEntries.length,
+    }),
+    [quiz, theme]
+  );
+
+  const pageConfig = MENU_PAGES.find((p) => p.id === 'settings');
+  if (!pageConfig) return null;
+
+  const canChangeMode = !quiz.isActive;
+
+  const handleItemClick = (item: MenuItemConfig) => {
+    if (item.action === 'navigate' && item.target) {
+      onPush(item.target as MenuPageId);
+    } else if (item.action === 'toggle' && item.target) {
+      const target = item.target as string;
+      if (target === 'arcade' || target === 'hardcore' || target === 'exam') {
+        if (canChangeMode) {
+          quiz.setGameMode(target as GameMode);
+        }
+      } else if (target === 'light' || target === 'dark' || target === 'system') {
+        setTheme(target);
+      }
+    }
+  };
+
+  const getDetail = (item: MenuItemConfig): string | undefined => {
+    if (!item.detail) return undefined;
+    return typeof item.detail === 'function' ? item.detail(context) : item.detail;
+  };
+
+  const isItemDisabled = (item: MenuItemConfig): boolean => {
+    if (typeof item.disabled === 'function') return item.disabled(context);
+    if (typeof item.disabled === 'boolean') return item.disabled;
+
+    // Block mode switch during active run
+    if (
+      item.action === 'toggle' &&
+      (item.target === 'arcade' || item.target === 'hardcore' || item.target === 'exam')
+    ) {
+      return !canChangeMode;
+    }
+
+    return false;
+  };
+
   return (
     <div className="py-2 space-y-6 px-4">
-      {/* Game Mode */}
-      <section>
-        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
-          Spielmodus
-        </h3>
-        <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
-          <MenuItem icon={<Zap className="w-5 h-5" />} label="Arcade" detail="Aktiv" />
-          <MenuItem icon={<Shield className="w-5 h-5" />} label="Hardcore" />
-          <MenuItem icon={<Timer className="w-5 h-5" />} label="Prüfungsmodus" />
-        </div>
-      </section>
-
-      {/* Theme */}
-      <section>
-        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
-          Erscheinungsbild
-        </h3>
-        <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
-          <MenuItem icon={<Sun className="w-5 h-5" />} label="Hell" />
-          <MenuItem icon={<Moon className="w-5 h-5" />} label="Dunkel" detail="Aktiv" />
-          <MenuItem icon={<Monitor className="w-5 h-5" />} label="System" />
-        </div>
-      </section>
-
-      {/* Data */}
-      <section>
-        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
-          Daten
-        </h3>
-        <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
-          <MenuItem icon={<Download className="w-5 h-5" />} label="Backup erstellen" onClick={() => onPush('data')} />
-          <MenuItem icon={<Upload className="w-5 h-5" />} label="Backup wiederherstellen" onClick={() => onPush('data')} />
-          <MenuItem icon={<Trash2 className="w-5 h-5" />} label="Alle Daten löschen" destructive onClick={() => onPush('data')} />
-        </div>
-      </section>
+      {pageConfig.sections?.map((section, sectionIndex) => (
+        <section key={sectionIndex}>
+          {section.title && (
+            <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
+              {section.title}
+            </h3>
+          )}
+          <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
+            {section.items.map((item) => (
+              <MenuItem
+                key={item.id}
+                icon={<item.icon className="w-5 h-5" />}
+                label={item.label}
+                detail={getDetail(item)}
+                onClick={() => handleItemClick(item)}
+                disabled={isItemDisabled(item)}
+                destructive={item.destructive}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
 
       {/* Info */}
       <section className="px-4 py-2">

--- a/src/components/game-menu/MenuPageSettings.tsx
+++ b/src/components/game-menu/MenuPageSettings.tsx
@@ -1,0 +1,51 @@
+import { Sun, Moon, Monitor, Zap, Shield, Timer, Download, Upload, Trash2 } from 'lucide-react';
+import { MenuItem } from './MenuItem';
+
+export function MenuPageSettings() {
+  return (
+    <div className="py-2 space-y-6 px-4">
+      {/* Game Mode */}
+      <section>
+        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
+          Spielmodus
+        </h3>
+        <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
+          <MenuItem icon={<Zap className="w-5 h-5" />} label="Arcade" detail="Aktiv" />
+          <MenuItem icon={<Shield className="w-5 h-5" />} label="Hardcore" />
+          <MenuItem icon={<Timer className="w-5 h-5" />} label="Prüfungsmodus" />
+        </div>
+      </section>
+
+      {/* Theme */}
+      <section>
+        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
+          Erscheinungsbild
+        </h3>
+        <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
+          <MenuItem icon={<Sun className="w-5 h-5" />} label="Hell" />
+          <MenuItem icon={<Moon className="w-5 h-5" />} label="Dunkel" detail="Aktiv" />
+          <MenuItem icon={<Monitor className="w-5 h-5" />} label="System" />
+        </div>
+      </section>
+
+      {/* Data */}
+      <section>
+        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
+          Daten
+        </h3>
+        <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
+          <MenuItem icon={<Download className="w-5 h-5" />} label="Backup erstellen" />
+          <MenuItem icon={<Upload className="w-5 h-5" />} label="Backup wiederherstellen" />
+          <MenuItem icon={<Trash2 className="w-5 h-5" />} label="Alle Daten löschen" destructive />
+        </div>
+      </section>
+
+      {/* Info */}
+      <section className="px-4 py-2">
+        <p className="text-xs text-slate-400 dark:text-slate-500 text-center">
+          Fisherman&apos;s Quiz v0.1.0
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/components/game-menu/MenuPageSettings.tsx
+++ b/src/components/game-menu/MenuPageSettings.tsx
@@ -1,7 +1,8 @@
 import { Sun, Moon, Monitor, Zap, Shield, Timer, Download, Upload, Trash2 } from 'lucide-react';
 import { MenuItem } from './MenuItem';
+import type { MenuPageId } from './menuConfig';
 
-export function MenuPageSettings() {
+export function MenuPageSettings({ onPush }: { onPush: (page: MenuPageId) => void }) {
   return (
     <div className="py-2 space-y-6 px-4">
       {/* Game Mode */}
@@ -34,9 +35,9 @@ export function MenuPageSettings() {
           Daten
         </h3>
         <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
-          <MenuItem icon={<Download className="w-5 h-5" />} label="Backup erstellen" />
-          <MenuItem icon={<Upload className="w-5 h-5" />} label="Backup wiederherstellen" />
-          <MenuItem icon={<Trash2 className="w-5 h-5" />} label="Alle Daten löschen" destructive />
+          <MenuItem icon={<Download className="w-5 h-5" />} label="Backup erstellen" onClick={() => onPush('data')} />
+          <MenuItem icon={<Upload className="w-5 h-5" />} label="Backup wiederherstellen" onClick={() => onPush('data')} />
+          <MenuItem icon={<Trash2 className="w-5 h-5" />} label="Alle Daten löschen" destructive onClick={() => onPush('data')} />
         </div>
       </section>
 

--- a/src/components/game-menu/index.ts
+++ b/src/components/game-menu/index.ts
@@ -1,0 +1,8 @@
+export { GameMenuOverlay } from './GameMenuOverlay';
+export { HUD } from './HUD';
+export { MenuItem } from './MenuItem';
+export { MenuPageData } from './MenuPageData';
+export { MenuPageList } from './MenuPageList';
+export { MenuPageRoot } from './MenuPageRoot';
+export { MenuPageSettings } from './MenuPageSettings';
+export * from './menuConfig';

--- a/src/components/game-menu/menuConfig.ts
+++ b/src/components/game-menu/menuConfig.ts
@@ -1,0 +1,302 @@
+import type { LucideIcon } from 'lucide-react';
+import {
+  Play,
+  Timer,
+  Settings,
+  Search,
+  History,
+  BarChart3,
+  LogOut,
+  Zap,
+  Shield,
+  Sun,
+  Moon,
+  Monitor,
+  Upload,
+  Trash2,
+  FileJson,
+  FileSpreadsheet,
+  Database,
+  RotateCcw,
+} from 'lucide-react';
+import type { GameMode, AppView } from '@/types/quiz';
+
+// ── Page IDs ──
+export type MenuPageId = 'root' | 'settings' | 'navigation' | 'run-actions' | 'data';
+
+// ── Action Types ──
+export type MenuActionType = 'navigate' | 'view' | 'action' | 'toggle';
+
+// ── Runtime Context for Conditions & Dynamic Details ──
+export interface MenuContext {
+  isQuizActive: boolean;
+  gameMode: GameMode;
+  theme: 'light' | 'dark' | 'system';
+  currentView: AppView;
+  historyCount: number;
+  runStatus?: string; // e.g. "3/20"
+}
+
+// ── Menu Item ──
+export interface MenuItemConfig {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  action: MenuActionType;
+  target?: MenuPageId | AppView | string;
+  detail?: string | ((ctx: MenuContext) => string);
+  condition?: (ctx: MenuContext) => boolean;
+  destructive?: boolean;
+  disabled?: boolean | ((ctx: MenuContext) => boolean);
+}
+
+// ── Menu Section ──
+export interface MenuSectionConfig {
+  title?: string;
+  items: MenuItemConfig[];
+}
+
+// ── Menu Page ──
+export interface MenuPageConfig {
+  id: MenuPageId;
+  title: string;
+  sections?: MenuSectionConfig[];
+  customComponent?: React.ComponentType;
+}
+
+// ── Helper to build detail strings ──
+const modeDetail = (ctx: MenuContext) => {
+  switch (ctx.gameMode) {
+    case 'arcade':
+      return 'Arcade';
+    case 'hardcore':
+      return 'Hardcore';
+    case 'exam':
+      return 'Prüfung';
+    default:
+      return '';
+  }
+};
+
+// ── Static Menu Configuration ──
+export const MENU_PAGES: MenuPageConfig[] = [
+  {
+    id: 'root',
+    title: 'Menü',
+    sections: [
+      {
+        items: [
+          {
+            id: 'continue-quiz',
+            label: 'Quiz fortsetzen',
+            icon: Play,
+            action: 'action',
+            target: 'continue-quiz',
+            condition: (ctx) => ctx.isQuizActive,
+          },
+        ],
+      },
+      {
+        title: 'Modus',
+        items: [
+          {
+            id: 'current-mode',
+            label: 'Spielmodus',
+            icon: Timer,
+            action: 'navigate',
+            target: 'settings',
+            detail: modeDetail,
+          },
+        ],
+      },
+      {
+        title: 'Allgemein',
+        items: [
+          {
+            id: 'settings',
+            label: 'Einstellungen',
+            icon: Settings,
+            action: 'navigate',
+            target: 'settings',
+          },
+          {
+            id: 'browse',
+            label: 'Fragenkatalog',
+            icon: Search,
+            action: 'view',
+            target: 'browse',
+          },
+          {
+            id: 'history',
+            label: 'Session-Verlauf',
+            icon: History,
+            action: 'view',
+            target: 'history',
+            detail: (ctx) => (ctx.historyCount > 0 ? `${ctx.historyCount}` : ''),
+          },
+          {
+            id: 'stats',
+            label: 'Statistiken',
+            icon: BarChart3,
+            action: 'view',
+            target: 'progress',
+            condition: (ctx) => ctx.isQuizActive,
+          },
+        ],
+      },
+      {
+        items: [
+          {
+            id: 'exit-quiz',
+            label: 'Quiz beenden',
+            icon: LogOut,
+            action: 'action',
+            target: 'exit-quiz',
+            destructive: true,
+            condition: (ctx) => ctx.isQuizActive,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'settings',
+    title: 'Einstellungen',
+    sections: [
+      {
+        title: 'Spielmodus',
+        items: [
+          {
+            id: 'mode-arcade',
+            label: 'Arcade',
+            icon: Zap,
+            action: 'toggle',
+            target: 'arcade',
+            detail: (ctx) => (ctx.gameMode === 'arcade' ? 'Aktiv' : ''),
+          },
+          {
+            id: 'mode-hardcore',
+            label: 'Hardcore',
+            icon: Shield,
+            action: 'toggle',
+            target: 'hardcore',
+            detail: (ctx) => (ctx.gameMode === 'hardcore' ? 'Aktiv' : ''),
+          },
+          {
+            id: 'mode-exam',
+            label: 'Prüfungsmodus',
+            icon: Timer,
+            action: 'toggle',
+            target: 'exam',
+            detail: (ctx) => (ctx.gameMode === 'exam' ? 'Aktiv' : ''),
+          },
+        ],
+      },
+      {
+        title: 'Erscheinungsbild',
+        items: [
+          {
+            id: 'theme-light',
+            label: 'Hell',
+            icon: Sun,
+            action: 'toggle',
+            target: 'light',
+            detail: (ctx) => (ctx.theme === 'light' ? 'Aktiv' : ''),
+          },
+          {
+            id: 'theme-dark',
+            label: 'Dunkel',
+            icon: Moon,
+            action: 'toggle',
+            target: 'dark',
+            detail: (ctx) => (ctx.theme === 'dark' ? 'Aktiv' : ''),
+          },
+          {
+            id: 'theme-system',
+            label: 'System',
+            icon: Monitor,
+            action: 'toggle',
+            target: 'system',
+            detail: (ctx) => (ctx.theme === 'system' ? 'Aktiv' : ''),
+          },
+        ],
+      },
+      {
+        title: 'Daten',
+        items: [
+          {
+            id: 'backup',
+            label: 'Backup & Daten',
+            icon: Database,
+            action: 'navigate',
+            target: 'data',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'data',
+    title: 'Backup & Daten',
+    sections: [
+      {
+        title: 'Export',
+        items: [
+          {
+            id: 'export-json',
+            label: 'Als JSON exportieren',
+            icon: FileJson,
+            action: 'action',
+            target: 'export-json',
+          },
+          {
+            id: 'export-csv',
+            label: 'Als CSV exportieren',
+            icon: FileSpreadsheet,
+            action: 'action',
+            target: 'export-csv',
+          },
+          {
+            id: 'export-full',
+            label: 'Vollständiges Backup',
+            icon: Database,
+            action: 'action',
+            target: 'export-full',
+          },
+        ],
+      },
+      {
+        title: 'Import',
+        items: [
+          {
+            id: 'import-progress',
+            label: 'Fortschritt importieren',
+            icon: Upload,
+            action: 'action',
+            target: 'import-progress',
+          },
+          {
+            id: 'import-full',
+            label: 'Vollständige Wiederherstellung',
+            icon: RotateCcw,
+            action: 'action',
+            target: 'import-full',
+          },
+        ],
+      },
+      {
+        title: 'Danger Zone',
+        items: [
+          {
+            id: 'delete-all',
+            label: 'Alle Daten löschen',
+            icon: Trash2,
+            action: 'action',
+            target: 'delete-all',
+            destructive: true,
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/src/hooks/useGameMenu.ts
+++ b/src/hooks/useGameMenu.ts
@@ -1,0 +1,89 @@
+import { useState, useCallback, useEffect } from 'react';
+
+export type MenuPageId = 'root' | 'settings' | 'navigation' | 'run-actions';
+
+interface GameMenuState {
+  isOpen: boolean;
+  stack: MenuPageId[];
+  direction: 'forward' | 'back';
+  focusedIndex: number;
+}
+
+export function useGameMenu() {
+  const [state, setState] = useState<GameMenuState>({
+    isOpen: false,
+    stack: ['root'],
+    direction: 'forward',
+    focusedIndex: 0,
+  });
+
+  const open = useCallback(() => {
+    setState(prev => ({
+      ...prev,
+      isOpen: true,
+      stack: ['root'],
+      direction: 'forward',
+      focusedIndex: 0,
+    }));
+  }, []);
+
+  const close = useCallback(() => {
+    setState(prev => ({
+      ...prev,
+      isOpen: false,
+      stack: ['root'],
+      direction: 'back',
+      focusedIndex: 0,
+    }));
+  }, []);
+
+  const push = useCallback((page: MenuPageId) => {
+    setState(prev => ({
+      ...prev,
+      stack: [...prev.stack, page],
+      direction: 'forward',
+      focusedIndex: 0,
+    }));
+  }, []);
+
+  const pop = useCallback(() => {
+    setState(prev => {
+      if (prev.stack.length <= 1) {
+        return { ...prev, isOpen: false, direction: 'back', focusedIndex: 0 };
+      }
+      return {
+        ...prev,
+        stack: prev.stack.slice(0, -1),
+        direction: 'back',
+        focusedIndex: 0,
+      };
+    });
+  }, []);
+
+  const currentPage = state.stack[state.stack.length - 1];
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!state.isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        pop();
+        return;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [state.isOpen, pop]);
+
+  return {
+    ...state,
+    currentPage,
+    open,
+    close,
+    push,
+    pop,
+  };
+}

--- a/src/hooks/useGameMenu.ts
+++ b/src/hooks/useGameMenu.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
+import type { MenuPageId } from '@/components/game-menu/menuConfig';
 
-export type MenuPageId = 'root' | 'settings' | 'navigation' | 'run-actions';
+export type { MenuPageId } from '@/components/game-menu/menuConfig';
 
 interface GameMenuState {
   isOpen: boolean;

--- a/src/hooks/useGameMenu.ts
+++ b/src/hooks/useGameMenu.ts
@@ -8,6 +8,7 @@ interface GameMenuState {
   stack: MenuPageId[];
   direction: 'forward' | 'back';
   focusedIndex: number;
+  itemCount: number;
 }
 
 export function useGameMenu() {
@@ -16,6 +17,7 @@ export function useGameMenu() {
     stack: ['root'],
     direction: 'forward',
     focusedIndex: 0,
+    itemCount: 0,
   });
 
   const open = useCallback(() => {
@@ -61,6 +63,32 @@ export function useGameMenu() {
     });
   }, []);
 
+  const openTo = useCallback((page: MenuPageId) => {
+    setState(prev => ({
+      ...prev,
+      isOpen: true,
+      stack: [page],
+      direction: 'forward',
+      focusedIndex: 0,
+    }));
+  }, []);
+
+  const resetFocus = useCallback(() => {
+    setState(prev => ({ ...prev, focusedIndex: 0 }));
+  }, []);
+
+  const setFocusedIndex = useCallback((index: number) => {
+    setState(prev => ({ ...prev, focusedIndex: index }));
+  }, []);
+
+  const registerItemCount = useCallback((count: number) => {
+    setState(prev => ({
+      ...prev,
+      itemCount: count,
+      focusedIndex: Math.min(prev.focusedIndex, Math.max(0, count - 1)),
+    }));
+  }, []);
+
   const currentPage = state.stack[state.stack.length - 1];
 
   // Keyboard navigation
@@ -68,10 +96,41 @@ export function useGameMenu() {
     if (!state.isOpen) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        pop();
-        return;
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setState(prev => ({
+            ...prev,
+            focusedIndex: Math.min(prev.focusedIndex + 1, Math.max(0, prev.itemCount - 1)),
+          }));
+          return;
+        case 'ArrowUp':
+          e.preventDefault();
+          setState(prev => ({
+            ...prev,
+            focusedIndex: Math.max(prev.focusedIndex - 1, 0),
+          }));
+          return;
+        case 'Home':
+          e.preventDefault();
+          setState(prev => ({ ...prev, focusedIndex: 0 }));
+          return;
+        case 'End':
+          e.preventDefault();
+          setState(prev => ({
+            ...prev,
+            focusedIndex: Math.max(0, prev.itemCount - 1),
+          }));
+          return;
+        case 'Enter':
+        case ' ':
+          e.preventDefault();
+          // Caller is responsible for wiring the actual action
+          return;
+        case 'Escape':
+          e.preventDefault();
+          pop();
+          return;
       }
     };
 
@@ -84,7 +143,11 @@ export function useGameMenu() {
     currentPage,
     open,
     close,
+    openTo,
     push,
     pop,
+    resetFocus,
+    setFocusedIndex,
+    registerItemCount,
   };
 }

--- a/src/views/QuizView.tsx
+++ b/src/views/QuizView.tsx
@@ -133,6 +133,10 @@ export default function QuizView({ quiz }: Props) {
         beantworteFrage(aktuelleFrage.id, buchstabe);
         setPendingWrongAnswer(null);
         checkBereichComplete(aktuelleFrage.id);
+      } else if (gameMode === 'arcade' && isPending) {
+        beantworteFrage(aktuelleFrage.id, buchstabe);
+        setPendingWrongAnswer(null);
+        checkBereichComplete(aktuelleFrage.id);
       } else if (gameMode === 'arcade' && !isPending) {
         setPendingWrongAnswer(buchstabe);
       } else {

--- a/src/views/StartView.tsx
+++ b/src/views/StartView.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
@@ -13,14 +13,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
-import { Separator } from '@/components/ui/separator';
-import { Fish, BookOpen, HelpCircle, Trophy, Target, Flame, RotateCcw, BarChart3, Trash2, CheckCircle, Star, Download, FileUp, HardDrive, Bell, FileJson, Table, Database, Crosshair, Layers, Repeat } from 'lucide-react';
+import { Fish, BookOpen, HelpCircle, Trophy, Target, Flame, RotateCcw, BarChart3, CheckCircle, Star, Crosshair, Layers, Repeat } from 'lucide-react';
 import type { QuizContext } from '@/hooks/useQuiz';
-import { MetaProgressionSchema } from '@/utils/quizLoader';
-import { buildCsv } from '@/utils/csvExport';
 import { isMastered } from '@/utils/srs';
 
 const BEREICHE = [
@@ -41,11 +35,6 @@ export default function StartView({ quiz }: Props) {
   const [fehler, setFehler] = useState('');
   const [nurFavoriten, setNurFavoriten] = useState(false);
   const [flashcardMode, setFlashcardMode] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const backupInputRef = useRef<HTMLInputElement>(null);
-  const [expJson, setExpJson] = useState(false);
-  const [expCsv, setExpCsv] = useState(false);
-  const [expBackup, setExpBackup] = useState(false);
 
   type DialogState =
     | { type: 'remove-arcade'; bereichId: string; fragenCount: number }
@@ -267,181 +256,8 @@ export default function StartView({ quiz }: Props) {
                     </div>
                   );
                 })}
-              </div>
-
-              {/* Export / Import / Reset */}
-              <div className="flex flex-wrap items-center justify-end gap-2">
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".json"
-                  className="hidden"
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (!file) return;
-                    const reader = new FileReader();
-                    reader.onload = (ev) => {
-                      try {
-                        const data = JSON.parse(ev.target?.result as string);
-                        const parsed = MetaProgressionSchema.safeParse(data);
-                        if (parsed.success) {
-                          if (confirm('Import progress data? This will overwrite current progress.')) {
-                            quiz.importMetaProgression?.(parsed.data);
-                          }
-                        } else {
-                          console.error('[Import] Validation failed:', parsed.error.format());
-                          alert('Invalid file format. The file does not contain valid progress data.');
-                        }
-                      } catch {
-                        alert('Error reading file.');
-                      }
-                      if (fileInputRef.current) fileInputRef.current.value = '';
-                    };
-                    reader.readAsText(file);
-                  }}
-                />
-                <input
-                  ref={backupInputRef}
-                  type="file"
-                  accept=".json"
-                  className="hidden"
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (!file) return;
-                    const reader = new FileReader();
-                    reader.onload = (ev) => {
-                      try {
-                        const data = JSON.parse(ev.target?.result as string);
-                        if (confirm('Restore full backup? This will overwrite ALL data and reload the page.')) {
-                          const ok = quiz.importFullBackup?.(data);
-                          if (ok === false) {
-                            alert('Invalid backup format.');
-                          }
-                        }
-                      } catch {
-                        alert('Error reading file.');
-                      }
-                      if (backupInputRef.current) backupInputRef.current.value = '';
-                    };
-                    reader.readAsText(file);
-                  }}
-                />
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      aria-label="Daten sichern und wiederherstellen"
-                      className="border-teal-300/50 text-teal-600 hover:bg-teal-50 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-teal-500/30 dark:text-teal-400 dark:hover:bg-teal-500/10 dark:focus-visible:ring-offset-slate-900 text-xs"
-                    >
-                      <HardDrive className="w-3 h-3 mr-1" aria-hidden="true" />Backup
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent align="end" className="w-64 p-3 space-y-3">
-                    <p className="text-sm font-semibold text-slate-900 dark:text-white">Backup &amp; Restore</p>
-
-                    <div className="space-y-2">
-                      <p className="text-xs font-medium text-slate-500 dark:text-slate-400">Export</p>
-                      <div className="space-y-1.5">
-                        <div className="flex items-center space-x-2">
-                          <Checkbox id="exp-json" checked={expJson} onCheckedChange={(v) => setExpJson(v === true)} />
-                          <Label htmlFor="exp-json" className="text-xs font-normal cursor-pointer flex items-center gap-1.5"><FileJson className="w-3 h-3 text-slate-400" />Progress (JSON)</Label>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          <Checkbox id="exp-csv" checked={expCsv} onCheckedChange={(v) => setExpCsv(v === true)} />
-                          <Label htmlFor="exp-csv" className="text-xs font-normal cursor-pointer flex items-center gap-1.5"><Table className="w-3 h-3 text-slate-400" />Stats (CSV)</Label>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          <Checkbox id="exp-backup" checked={expBackup} onCheckedChange={(v) => setExpBackup(v === true)} />
-                          <Label htmlFor="exp-backup" className="text-xs font-normal cursor-pointer flex items-center gap-1.5"><Database className="w-3 h-3 text-slate-400" />Full Backup</Label>
-                        </div>
-                      </div>
-                      <Button
-                        size="sm"
-                        className="w-full text-xs h-8 bg-teal-600 hover:bg-teal-700 text-white"
-                        disabled={!expJson && !expCsv && !expBackup}
-                        onClick={() => {
-                          if (expJson) {
-                            const data = quiz.metaProgress;
-                            const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-                            const url = URL.createObjectURL(blob);
-                            const a = document.createElement('a');
-                            a.href = url;
-                            a.download = `fishermans-quiz-meta-${new Date().toISOString().split('T')[0]}.json`;
-                            a.click();
-                            URL.revokeObjectURL(url);
-                          }
-                          if (expCsv) {
-                            const rows = [
-                              ['Frage-ID', 'Bereich', 'Versuche', 'Serie', 'Letztes Ergebnis', 'Erst gesehen', 'Zuletzt'],
-                              ...Object.entries(quiz.metaProgress.fragen).map(([id, m]) => [
-                                id,
-                                quiz.quizMeta?.fragenIndex?.[id] ?? '',
-                                String(m.attempts),
-                                String(m.correctStreak),
-                                m.lastResult ?? '',
-                                m.firstSeen,
-                                m.lastAttempt,
-                              ]),
-                            ];
-                            const csv = buildCsv(rows);
-                            const blob = new Blob([csv], { type: 'text/csv' });
-                            const url = URL.createObjectURL(blob);
-                            const a = document.createElement('a');
-                            a.href = url;
-                            a.download = `fishermans-quiz-stats-${new Date().toISOString().split('T')[0]}.csv`;
-                            a.click();
-                            URL.revokeObjectURL(url);
-                          }
-                          if (expBackup) {
-                            quiz.exportFullBackup?.();
-                          }
-                        }}
-                      >
-                        <Download className="w-3 h-3 mr-1" />Export
-                      </Button>
-                    </div>
-
-                    <Separator />
-
-                    <div className="space-y-2">
-                      <p className="text-xs font-medium text-slate-500 dark:text-slate-400">Import</p>
-                      <div className="flex gap-2">
-                        <Button variant="outline" size="sm" className="flex-1 text-xs h-8" onClick={() => fileInputRef.current?.click()}>
-                          <FileUp className="w-3 h-3 mr-1" />Progress
-                        </Button>
-                        <Button variant="outline" size="sm" className="flex-1 text-xs h-8" onClick={() => backupInputRef.current?.click()}>
-                          <RotateCcw className="w-3 h-3 mr-1" />Full Restore
-                        </Button>
-                      </div>
-                    </div>
-
-                    <Separator />
-
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="w-full text-xs h-8 text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-500/10"
-                      onClick={() => { if (confirm('Delete all data? This cannot be undone.')) { quiz.resetMetaProgression(); quiz.resetSRS?.(); } }}
-                    >
-                      <Trash2 className="w-3 h-3 mr-1" />Delete All Data
-                    </Button>
-                  </PopoverContent>
-                </Popover>
-              </div>
-
-              {/* Backup-Erinnerung */}
-              <div className="mt-3 flex items-center gap-2">
-                <button
-                  onClick={() => quiz.setBackupReminderEnabled?.(!quiz.backupReminderEnabled)}
-                  aria-pressed={quiz.backupReminderEnabled}
-                  className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium transition-colors ${quiz.backupReminderEnabled ? 'bg-teal-50 text-teal-600 border border-teal-300/50 dark:bg-teal-500/10 dark:text-teal-400 dark:border-teal-500/30' : 'text-slate-500 hover:text-slate-700 border border-transparent dark:text-slate-400 dark:hover:text-slate-300'}`}
-                >
-                  <Bell className={`w-3.5 h-3.5 ${quiz.backupReminderEnabled ? 'fill-current' : ''}`} />
-                  Backup reminder {quiz.backupReminderEnabled ? 'on' : 'off'}
-                </button>
-              </div>
-            </CardContent>
+               </div>
+             </CardContent>
           </Card>
 
           {/* Bereichsauswahl */}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -72,11 +72,26 @@ module.exports = {
           "0%,70%,100%": { opacity: "1" },
           "20%,50%": { opacity: "0" },
         },
+        "slide-in-from-right": {
+          "0%": { transform: "translateX(100%)" },
+          "100%": { transform: "translateX(0)" },
+        },
+        "slide-in-from-left": {
+          "0%": { transform: "translateX(-100%)" },
+          "100%": { transform: "translateX(0)" },
+        },
+        "fade-in": {
+          "0%": { opacity: "0" },
+          "100%": { opacity: "1" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         "caret-blink": "caret-blink 1.25s ease-out infinite",
+        "slide-in-right": "slide-in-from-right 0.3s ease-out",
+        "slide-in-left": "slide-in-from-left 0.3s ease-out",
+        "fade-in": "fade-in 0.2s ease-out",
       },
     },
   },


### PR DESCRIPTION
Closes #142

## Summary

Rewrites `MenuPageRoot`, `MenuPageSettings`, and `MenuItem` from spike code to production implementations that consume the `MENU_PAGES` config array and wire all actions to real state mutators.

## Changes

### `MenuPageRoot`
- Consumes `MENU_PAGES` config for the `root` page
- Maps sections and items dynamically
- "Quiz fortsetzen" CTA closes menu when quiz is active; hidden when inactive (via config `condition`)
- "Einstellungen" pushes `settings` page
- "Fragenkatalog" calls `quiz.goToView('browse')` and closes menu
- "Session-Verlauf" calls `quiz.goToView('history')` and closes menu
- "Statistiken" calls `quiz.goToView('progress')` and closes menu (only when active)
- "Quiz beenden" shows confirmation `AlertDialog` (reusing existing pattern), then calls `quiz.unterbrecheRun()`

### `MenuPageSettings`
- Consumes `MENU_PAGES` config for the `settings` page
- Game mode rows call `quiz.setGameMode(mode)`; active mode shown with "Aktiv" detail
- Mode switch blocked during active run (disabled state)
- Theme rows call `setTheme()` from `next-themes`; active theme shown
- "Daten" section item pushes `data` page

### `MenuItem`
- `tabIndex={isFocused ? 0 : -1}` when used inside menu list
- Supports `aria-label` propagation
- Focus ring uses `focus-visible:ring-2 focus-visible:ring-teal-400`

### `GameMenuOverlay`
- Updated to pass `quiz` and `onClose` props to `MenuPageRoot` and `MenuPageSettings`

## Checklist

- [x] `npm run lint` clean
- [x] `npm run test:run` all tests green (160 passed)
- [x] `npm run build` clean
