### PR TITLE
chore(qa-fixes): batch trivial code-quality fixes from review (#164)

### DIFF
--- a/src/components/game-menu/GameMenuOverlay.tsx
+++ b/src/components/game-menu/GameMenuOverlay.tsx
@@ -45,7 +45,10 @@ export function GameMenuOverlay({
   // Store previously focused element when opening, restore on close
   useEffect(() => {
     if (isOpen) {
-      lastFocusedRef.current = document.activeElement as HTMLElement;
+      const active = document.activeElement;
+      if (active instanceof HTMLElement) {
+        lastFocusedRef.current = active;
+      }
     } else if (lastFocusedRef.current) {
       lastFocusedRef.current.focus();
       lastFocusedRef.current = null;
@@ -98,7 +101,7 @@ export function GameMenuOverlay({
           return <MenuPageRoot onPush={onPush} onClose={onClose} quiz={quiz} />;
       }
     },
-    [onPush, onClose, quiz]
+    [onPush, onClose, onPop, quiz]
   );
 
   const header = (

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -253,7 +253,7 @@ export function useQuiz() {
     const sessionType = options.sessionType ?? 'quiz';
     run.starteRun(bereiche, filteredData, limit, durationSeconds, sessionType);
     if (isNewRun) meta.recordRunStart();
-    setView(sessionType === 'flashcard' ? 'quiz' : 'quiz');
+    setView('quiz');
   }, [run, meta, quizData, quizMeta, fav.favorites, gameMode, srs.dueFrageIds]);
 
   const goToView = useCallback((v: AppView) => setView(v), []);


### PR DESCRIPTION
## Summary

Batch three trivial one-line fixes identified during the Code QA review (#158, #159, #163). Each fix is independent, touches a different file, and has zero behavioral impact.

## Fixes Included

### 1. Missing `onPop` dependency (#158)
**File:** `src/components/game-menu/GameMenuOverlay.tsx:101`

Added `onPop` to the `useCallback` dependency array to eliminate the ESLint warning and prevent stale closure bugs.

### 2. Dead ternary in `starteQuiz` (#159)
**File:** `src/hooks/useQuiz.ts:256`

Simplified the pointless ternary `setView(sessionType === 'flashcard' ? 'quiz' : 'quiz')` to just `setView('quiz')`.

### 3. Null check before focus restoration (#163)
**File:** `src/components/game-menu/GameMenuOverlay.tsx:46-53`

Added a type guard (`instanceof HTMLElement`) when storing `document.activeElement` to ensure type safety.

## Verification

✅ `npm run lint` passes with zero warnings  
✅ `npm run test:run` all 191 tests pass  
✅ `npm run build` clean

## Related Issues

Closes #158, closes #159, closes #163.