### PR TITLE
fix(game-menu): wire Enter/Space keyboard activation in useGameMenu (#161)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,7 @@ export default function App() {
         onClose={gameMenu.close}
         onPop={gameMenu.pop}
         onPush={gameMenu.push}
+        registerOnActivate={gameMenu.registerOnActivate}
         quiz={quiz}
       />
 

--- a/src/components/game-menu/GameMenuOverlay.tsx
+++ b/src/components/game-menu/GameMenuOverlay.tsx
@@ -18,6 +18,7 @@ interface GameMenuOverlayProps {
   onClose: () => void;
   onPop: () => void;
   onPush: (page: MenuPageId) => void;
+  registerOnActivate: (cb: ((index: number) => void) | null) => void;
   quiz: QuizContext;
 }
 
@@ -32,6 +33,7 @@ export function GameMenuOverlay({
   onClose,
   onPop,
   onPush,
+  registerOnActivate,
   quiz,
 }: GameMenuOverlayProps) {
   const isMobile = useIsMobile();
@@ -66,6 +68,19 @@ export function GameMenuOverlay({
     }, 50);
     return () => clearTimeout(timer);
   }, [isOpen, currentPage]);
+
+  // Wire Enter/Space activation to the focused menu item
+  useEffect(() => {
+    registerOnActivate((index) => {
+      const panel = panelRef.current;
+      if (!panel) return;
+      const items = panel.querySelectorAll<HTMLElement>('[data-menu-item]');
+      if (index >= 0 && index < items.length) {
+        items[index].click();
+      }
+    });
+    return () => registerOnActivate(null);
+  }, [registerOnActivate]);
 
   // Body scroll lock on desktop (vaul handles mobile)
   useEffect(() => {

--- a/src/components/game-menu/MenuItem.tsx
+++ b/src/components/game-menu/MenuItem.tsx
@@ -24,6 +24,7 @@ export function MenuItem({
 }: MenuItemProps) {
   return (
     <button
+      data-menu-item
       onClick={onClick}
       disabled={disabled}
       tabIndex={isFocused === true ? 0 : isFocused === false ? -1 : undefined}

--- a/src/components/game-menu/MenuPageData.tsx
+++ b/src/components/game-menu/MenuPageData.tsx
@@ -61,6 +61,7 @@ export function MenuPageData({ quiz }: MenuPageDataProps) {
           </div>
           <div className="px-4 pb-3">
             <Button
+              data-menu-item
               size="sm"
               className="w-full"
               disabled={!expJson && !expCsv && !expBackup}
@@ -171,11 +172,11 @@ export function MenuPageData({ quiz }: MenuPageDataProps) {
             }}
           />
           <div className="px-4 py-3 grid grid-cols-2 gap-3">
-            <Button variant="outline" size="sm" className="h-8" onClick={() => fileInputRef.current?.click()}>
+            <Button data-menu-item variant="outline" size="sm" className="h-8" onClick={() => fileInputRef.current?.click()}>
               <Upload className="w-4 h-4 mr-2" />
               Progress
             </Button>
-            <Button variant="outline" size="sm" className="h-8" onClick={() => backupInputRef.current?.click()}>
+            <Button data-menu-item variant="outline" size="sm" className="h-8" onClick={() => backupInputRef.current?.click()}>
               <RotateCcw className="w-4 h-4 mr-2" />
               Full Restore
             </Button>
@@ -190,6 +191,7 @@ export function MenuPageData({ quiz }: MenuPageDataProps) {
         </h3>
         <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
           <Button
+            data-menu-item
             variant="ghost"
             size="sm"
             className="w-full justify-start px-4 py-3 h-auto text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-500/10"
@@ -212,6 +214,7 @@ export function MenuPageData({ quiz }: MenuPageDataProps) {
       {/* Backup Reminder */}
       <section className="px-4">
         <button
+          data-menu-item
           onClick={() => quiz.setBackupReminderEnabled?.(!quiz.backupReminderEnabled)}
           aria-pressed={quiz.backupReminderEnabled}
           className={`w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm font-medium transition-colors border ${

--- a/src/components/game-menu/MenuPageNavigation.tsx
+++ b/src/components/game-menu/MenuPageNavigation.tsx
@@ -52,6 +52,7 @@ export function MenuPageNavigation({ quiz, onClose }: MenuPageNavigationProps) {
 
             return (
               <button
+                data-menu-item
                 key={frage.id}
                 onClick={() => handleJump(idx)}
                 aria-label={`Frage ${idx + 1}${stateLabel}`}

--- a/src/components/game-menu/MenuPageRoot.tsx
+++ b/src/components/game-menu/MenuPageRoot.tsx
@@ -97,6 +97,7 @@ export function MenuPageRoot({ onPush, onClose, quiz }: MenuPageRootProps) {
           return (
             <div key={sectionIndex} className="px-4 pb-3">
               <button
+                data-menu-item
                 onClick={() => handleItemClick(item)}
                 disabled={!quiz.isActive}
                 className="w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-teal-500 text-white font-semibold text-[15px] hover:bg-teal-600 active:scale-[0.98] transition-all disabled:opacity-40 disabled:cursor-not-allowed"

--- a/src/components/game-menu/MenuPageRunActions.tsx
+++ b/src/components/game-menu/MenuPageRunActions.tsx
@@ -62,6 +62,7 @@ export function MenuPageRunActions({ quiz, onClose }: MenuPageComponentProps) {
       {/* Primary CTA: Continue */}
       <section>
         <button
+          data-menu-item
           onClick={handleContinue}
           aria-label="Quiz fortsetzen"
           className="w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-teal-500 text-white font-semibold text-[15px] hover:bg-teal-600 active:scale-[0.98] transition-all"
@@ -78,6 +79,7 @@ export function MenuPageRunActions({ quiz, onClose }: MenuPageComponentProps) {
         </h3>
         <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
           <button
+            data-menu-item
             onClick={handleRestart}
             aria-label="Quiz neu starten"
             className="w-full flex items-center gap-3 px-4 py-3 text-left transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:outline-none active:scale-[0.98] cursor-pointer hover:bg-accent/50 text-foreground"
@@ -89,6 +91,7 @@ export function MenuPageRunActions({ quiz, onClose }: MenuPageComponentProps) {
           </button>
 
           <button
+            data-menu-item
             onClick={handleProgress}
             aria-label="Zum Fortschritt"
             className="w-full flex items-center gap-3 px-4 py-3 text-left transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:outline-none active:scale-[0.98] cursor-pointer hover:bg-accent/50 text-foreground"
@@ -100,6 +103,7 @@ export function MenuPageRunActions({ quiz, onClose }: MenuPageComponentProps) {
           </button>
 
           <button
+            data-menu-item
             onClick={handleExit}
             aria-label="Zur Startseite"
             className="w-full flex items-center gap-3 px-4 py-3 text-left transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:outline-none active:scale-[0.98] cursor-pointer hover:bg-accent/50 text-red-500 dark:text-red-400"

--- a/src/hooks/useGameMenu.ts
+++ b/src/hooks/useGameMenu.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import type { MenuPageId } from '@/components/game-menu/menuConfig';
 
 export type { MenuPageId } from '@/components/game-menu/menuConfig';
@@ -91,6 +91,17 @@ export function useGameMenu() {
 
   const currentPage = state.stack[state.stack.length - 1];
 
+  // Refs to avoid stale closures in the global keydown listener
+  const focusedIndexRef = useRef(state.focusedIndex);
+  useEffect(() => {
+    focusedIndexRef.current = state.focusedIndex;
+  }, [state.focusedIndex]);
+
+  const onActivateRef = useRef<((index: number) => void) | null>(null);
+  const registerOnActivate = useCallback((cb: ((index: number) => void) | null) => {
+    onActivateRef.current = cb;
+  }, []);
+
   // Keyboard navigation
   useEffect(() => {
     if (!state.isOpen) return;
@@ -125,7 +136,7 @@ export function useGameMenu() {
         case 'Enter':
         case ' ':
           e.preventDefault();
-          // Caller is responsible for wiring the actual action
+          onActivateRef.current?.(focusedIndexRef.current);
           return;
         case 'Escape':
           e.preventDefault();
@@ -149,5 +160,6 @@ export function useGameMenu() {
     resetFocus,
     setFocusedIndex,
     registerItemCount,
+    registerOnActivate,
   };
 }

--- a/src/test/gameMenu.test.ts
+++ b/src/test/gameMenu.test.ts
@@ -241,35 +241,68 @@ describe('useGameMenu', () => {
     expect(result.current.stack).toEqual(['root']);
   });
 
-  it('Enter does not crash', () => {
+  it('Enter fires registered onActivate callback with focusedIndex', () => {
+    const onActivate = vi.fn();
     const { result } = renderHook(() => useGameMenu());
 
     act(() => {
+      result.current.registerItemCount(5);
+    });
+    act(() => {
       result.current.open();
     });
+    act(() => {
+      result.current.setFocusedIndex(2);
+    });
+    act(() => {
+      result.current.registerOnActivate(onActivate);
+    });
 
-    expect(() => {
-      act(() => {
-        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-      });
-    }).not.toThrow();
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    });
 
+    expect(onActivate).toHaveBeenCalledWith(2);
     expect(result.current.isOpen).toBe(true);
   });
 
-  it('Space does not crash', () => {
+  it('Space fires registered onActivate callback with focusedIndex', () => {
+    const onActivate = vi.fn();
     const { result } = renderHook(() => useGameMenu());
 
     act(() => {
       result.current.open();
     });
+    act(() => {
+      result.current.registerOnActivate(onActivate);
+    });
 
-    expect(() => {
-      act(() => {
-        window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
-      });
-    }).not.toThrow();
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+    });
 
+    expect(onActivate).toHaveBeenCalledWith(0);
     expect(result.current.isOpen).toBe(true);
+  });
+
+  it('unregistering onActivate stops Enter from firing', () => {
+    const onActivate = vi.fn();
+    const { result } = renderHook(() => useGameMenu());
+
+    act(() => {
+      result.current.open();
+    });
+    act(() => {
+      result.current.registerOnActivate(onActivate);
+    });
+    act(() => {
+      result.current.registerOnActivate(null);
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    });
+
+    expect(onActivate).not.toHaveBeenCalled();
   });
 });

--- a/src/test/gameMenuComponents.test.tsx
+++ b/src/test/gameMenuComponents.test.tsx
@@ -226,9 +226,11 @@ describe('GameMenuOverlay', () => {
         stack={['root']}
         currentPage="root"
         direction="forward"
+        focusedIndex={0}
         onClose={vi.fn()}
         onPop={vi.fn()}
         onPush={vi.fn()}
+        registerOnActivate={vi.fn()}
         quiz={mockQuiz}
       />,
     );
@@ -243,9 +245,11 @@ describe('GameMenuOverlay', () => {
         stack={['root']}
         currentPage="root"
         direction="forward"
+        focusedIndex={0}
         onClose={vi.fn()}
         onPop={vi.fn()}
         onPush={vi.fn()}
+        registerOnActivate={vi.fn()}
         quiz={mockQuiz}
       />,
     );
@@ -261,9 +265,11 @@ describe('GameMenuOverlay', () => {
         stack={['root']}
         currentPage="root"
         direction="forward"
+        focusedIndex={0}
         onClose={onClose}
         onPop={vi.fn()}
         onPush={vi.fn()}
+        registerOnActivate={vi.fn()}
         quiz={mockQuiz}
       />,
     );


### PR DESCRIPTION
Fixes #161

## Changes

- **`useGameMenu.ts`**: Added `registerOnActivate` callback registration. Enter/Space now fire the registered callback with the current `focusedIndex` instead of being no-ops.
- **`GameMenuOverlay.tsx`**: Registers an activation handler that queries the DOM for `[data-menu-item]` elements and clicks the one at the focused index.
- **`MenuItem.tsx`**: Added `data-menu-item` attribute to its `<button>` so it can be discovered by the overlay's activation handler.
- **Page components** (`MenuPageRoot`, `MenuPageRunActions`, `MenuPageNavigation`, `MenuPageData`): Added `data-menu-item` to custom interactive buttons so they participate in keyboard activation.
- **Tests**: Replaced "does not crash" smoke tests with proper assertions verifying that `registerOnActivate` callbacks are invoked with the correct `focusedIndex` on Enter/Space, and that unregistering stops activation.

## Verification

- [x] Pressing Enter or Space on a focused menu item triggers its action
- [x] Existing keyboard navigation (ArrowUp/ArrowDown, Escape, Home, End) still works
- [x] `npm run test:run` all green (192 tests)
- [x] `npm run build` clean
- [x] `npm run lint` clean