### PR TITLE
fix(menu): restore menu item clicks, fix ProgressView dead end, add Enter shortcuts

### DIFF
--- a/src/components/game-menu/GameMenuOverlay.tsx
+++ b/src/components/game-menu/GameMenuOverlay.tsx
@@ -101,11 +101,7 @@ export function GameMenuOverlay({
         return <Component quiz={quiz} onClose={onClose} onPop={onPop} onPush={onPush} />;
       }
 
-      if (config?.sections) {
-        return <MenuPageList sections={config.sections} />;
-      }
-
-      // Legacy fallback for pages not yet fully migrated to config
+      // Known pages with dedicated components take precedence over generic section rendering
       switch (page) {
         case 'root':
           return <MenuPageRoot onPush={onPush} onClose={onClose} quiz={quiz} />;
@@ -114,8 +110,14 @@ export function GameMenuOverlay({
         case 'data':
           return <MenuPageData quiz={quiz} />;
         default:
-          return <MenuPageRoot onPush={onPush} onClose={onClose} quiz={quiz} />;
+          break;
       }
+
+      if (config?.sections) {
+        return <MenuPageList sections={config.sections} />;
+      }
+
+      return <MenuPageRoot onPush={onPush} onClose={onClose} quiz={quiz} />;
     },
     [onPush, onClose, onPop, quiz]
   );

--- a/src/components/game-menu/MenuPageList.tsx
+++ b/src/components/game-menu/MenuPageList.tsx
@@ -1,11 +1,12 @@
 import { MenuItem } from './MenuItem';
-import type { MenuSectionConfig } from './menuConfig';
+import type { MenuSectionConfig, MenuItemConfig } from './menuConfig';
 
 interface MenuPageListProps {
   sections?: MenuSectionConfig[];
+  onItemClick?: (item: MenuItemConfig) => void;
 }
 
-export function MenuPageList({ sections }: MenuPageListProps) {
+export function MenuPageList({ sections, onItemClick }: MenuPageListProps) {
   if (!sections || sections.length === 0) return null;
 
   return (
@@ -27,6 +28,7 @@ export function MenuPageList({ sections }: MenuPageListProps) {
                   label={item.label}
                   detail={detail}
                   destructive={item.destructive}
+                  onClick={onItemClick ? () => onItemClick(item) : undefined}
                 />
               );
             })}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -38,6 +38,10 @@ export function useKeyboardShortcuts(options: KeyboardShortcutsOptions) {
         if (INPUT_TAGS.has(tag) || target.getAttribute(EDITABLE_ATTR) === 'true') {
           return;
         }
+        // Skip Enter on buttons/links to avoid double-firing native click + shortcut
+        if (event.key === 'Enter' && (tag === 'BUTTON' || tag === 'A')) {
+          return;
+        }
       }
 
       // Prevent browser defaults only when handler is registered
@@ -48,6 +52,9 @@ export function useKeyboardShortcuts(options: KeyboardShortcutsOptions) {
         event.preventDefault();
       }
       if (event.key === 'ArrowRight' && onNext) {
+        event.preventDefault();
+      }
+      if (event.key === 'Enter' && onNext) {
         event.preventDefault();
       }
 
@@ -65,6 +72,9 @@ export function useKeyboardShortcuts(options: KeyboardShortcutsOptions) {
           onPrev?.();
           break;
         case 'ArrowRight':
+          onNext?.();
+          break;
+        case 'Enter':
           onNext?.();
           break;
         case ' ':

--- a/src/views/ProgressView.tsx
+++ b/src/views/ProgressView.tsx
@@ -1,7 +1,9 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
-import { CheckCircle, XCircle, HelpCircle, ChevronDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { CheckCircle, XCircle, HelpCircle, ChevronDown, ArrowLeft, Play } from 'lucide-react';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import type { QuizContext } from '@/hooks/useQuiz';
 
 interface Props {
@@ -9,7 +11,7 @@ interface Props {
 }
 
 export default function ProgressView({ quiz }: Props) {
-  const { statistiken, aktiveFragen, antworten, springeZuFrage, getFrageMeta } = quiz;
+  const { statistiken, aktiveFragen, antworten, springeZuFrage, getFrageMeta, goToView, isActive } = quiz;
   const [showWrong, setShowWrong] = useState(false);
   const [showUnanswered, setShowUnanswered] = useState(false);
   const headingRef = useRef<HTMLHeadingElement>(null);
@@ -17,6 +19,17 @@ export default function ProgressView({ quiz }: Props) {
   useEffect(() => {
     headingRef.current?.focus();
   }, []);
+
+  useKeyboardShortcuts({
+    onEscape: () => {
+      if (isActive) {
+        goToView('quiz');
+      } else {
+        goToView('start');
+      }
+    },
+    enabled: true,
+  });
 
   const pct = statistiken.gesamt > 0 ? (statistiken.korrekt / statistiken.gesamt) * 100 : 0;
   const passed = pct >= 60;
@@ -110,7 +123,7 @@ export default function ProgressView({ quiz }: Props) {
                         <div className="flex items-start justify-between gap-3 mb-1.5">
                           <p className="text-slate-900 font-medium text-sm leading-snug dark:text-white">{frage.frage}</p>
                           <button
-                            onClick={() => { const idx = aktiveFragen.findIndex(f => f.id === frage.id); if (idx >= 0) springeZuFrage(idx); }}
+                            onClick={() => { const idx = aktiveFragen.findIndex(f => f.id === frage.id); if (idx >= 0) { springeZuFrage(idx); goToView('quiz'); } }}
                             className="text-teal-600 text-xs hover:underline whitespace-nowrap flex-shrink-0 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-teal-400 dark:focus-visible:ring-offset-slate-900 rounded"
                           >
                             Zur Frage
@@ -153,7 +166,7 @@ export default function ProgressView({ quiz }: Props) {
                     return (
                       <button
                         key={frage.id}
-                        onClick={() => springeZuFrage(idx)}
+                        onClick={() => { springeZuFrage(idx); goToView('quiz'); }}
                         aria-label={`Zu unbeantworteter Frage ${idx + 1} springen`}
                         className="px-2.5 py-1 rounded-md text-xs font-medium bg-amber-50 text-amber-600 border border-amber-300/50 hover:bg-amber-100 transition-all focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-amber-500/10 dark:text-amber-400 dark:border-amber-500/20 dark:hover:bg-amber-500/20 dark:focus-visible:ring-offset-slate-900"
                       >
@@ -165,6 +178,33 @@ export default function ProgressView({ quiz }: Props) {
                )}
              </CardContent>
            </Card>
+
+        {/* Continue Quiz Button */}
+        {isActive && (
+          <div className="sticky bottom-4 flex justify-center">
+            <Button
+              onClick={() => goToView('quiz')}
+              className="bg-teal-500 hover:bg-teal-600 text-white font-semibold px-6 py-5 text-sm rounded-xl shadow-lg shadow-teal-500/20 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+            >
+              <Play className="w-4 h-4 mr-2" />
+              Quiz fortsetzen
+            </Button>
+          </div>
+        )}
+
+        {/* Back to Start */}
+        {!isActive && (
+          <div className="flex justify-center mt-4">
+            <Button
+              variant="outline"
+              onClick={() => goToView('start')}
+              className="rounded-xl border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+            >
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              Zurück zur Startseite
+            </Button>
+          </div>
+        )}
        </div>
      </div>
    );

--- a/src/views/StartView.tsx
+++ b/src/views/StartView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
@@ -77,9 +77,12 @@ export default function StartView({ quiz }: Props) {
     return null;
   }
 
-  const effektivAusgewaehlt = isActive
-    ? [...new Set([...geladeneBereiche, ...ausgewaehlt])]
-    : ausgewaehlt;
+  const effektivAusgewaehlt = useMemo(() =>
+    isActive
+      ? [...new Set([...geladeneBereiche, ...ausgewaehlt])]
+      : ausgewaehlt,
+    [isActive, geladeneBereiche, ausgewaehlt]
+  );
 
   const toggle = (id: string) => {
     setFehler('');
@@ -107,7 +110,7 @@ export default function StartView({ quiz }: Props) {
     }
   };
 
-  const handleStart = () => {
+  const handleStart = useCallback(() => {
     if (effektivAusgewaehlt.length === 0) {
       setFehler('Bitte wähle mindestens einen Bereich aus.');
       return;
@@ -117,7 +120,26 @@ export default function StartView({ quiz }: Props) {
       return;
     }
     quiz.starteQuiz(effektivAusgewaehlt, { nurFavoriten, sessionType: flashcardMode ? 'flashcard' : 'quiz' });
-  };
+  }, [effektivAusgewaehlt, nurFavoriten, quiz, flashcardMode]);
+
+  // Global Enter handler to start quiz when areas are selected
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && effektivAusgewaehlt.length > 0) {
+        // Only trigger if focus is not inside a button or interactive element
+        const target = e.target;
+        if (target instanceof Element) {
+          const tag = target.tagName;
+          if (tag === 'BUTTON' || tag === 'A' || tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+            return;
+          }
+        }
+        handleStart();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [effektivAusgewaehlt, handleStart]);
 
   const handleWeaknessTrainer = () => {
     const allBereiche = BEREICHE.map(b => b.id);


### PR DESCRIPTION
Closes #189

## Summary

Fixes the critical menu regression where **all main menu items were visible but completely non-interactive**, plus three related navigation/keyboard issues.

## Changes

### 1. GameMenuOverlay precedence bug (Critical)
`GameMenuOverlay.tsx` checked `config?.sections` before the legacy fallback, so `root`/`settings`/`data` pages were rendered by `MenuPageList` which **does not pass `onClick` handlers**. The switch statement now runs before the generic sections renderer, restoring all menu functionality:
- "Quiz fortsetzen"
- "Einstellungen" / "Spielmodus"
- "Fragenkatalog" / "Session-Verlauf"
- "Backup & Daten"
- "Quiz beenden"

### 2. MenuPageList safety net
Added optional `onItemClick` prop to `MenuPageList` so future pages using generic section rendering won't be completely dead.

### 3. ProgressView dead end fixed
- "Zur Frage" / "Frage X" buttons now correctly call `goToView('quiz')` before jumping
- Added visible **"Quiz fortsetzen"** (sticky bottom) or **"Zurück zur Startseite"** button
- Added **Escape** keyboard shortcut to exit ProgressView

### 4. StartView Enter key
Pressing **Enter** anywhere in StartView (when not focused on a button/link/input) now starts the quiz if at least one Bereich is selected.

### 5. QuizView Enter key
Added **Enter** → `onNext` in `useKeyboardShortcuts`, with a guard that skips when focus is on a `<button>` or `<a>` to avoid double-firing.

## Verification

- [x] `npm run lint` — clean
- [x] `npm run test:run` — 192 tests green
- [x] `npm run build` — clean

## Files changed

- `src/components/game-menu/GameMenuOverlay.tsx`
- `src/components/game-menu/MenuPageList.tsx`
- `src/views/ProgressView.tsx`
- `src/views/StartView.tsx`
- `src/hooks/useKeyboardShortcuts.ts`
