### PR TITLE
fix(ui): move HUD to bottom, fix mobile drawer, continue-quiz in HUD

### DIFF
--- a/src/components/game-menu/GameMenuOverlay.tsx
+++ b/src/components/game-menu/GameMenuOverlay.tsx
@@ -174,7 +174,6 @@ export function GameMenuOverlay({
         onOpenChange={(open) => {
           if (!open) onClose();
         }}
-        snapPoints={[0.5, 0.85]}
         dismissible
       >
         <DrawerPrimitive.Portal>

--- a/src/components/game-menu/HUD.tsx
+++ b/src/components/game-menu/HUD.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { Home, Menu, BarChart3, Square } from 'lucide-react';
+import { Home, Menu, BarChart3, Square, Play } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { QuizContext } from '@/hooks/useQuiz';
 import type { MenuPageId } from '@/hooks/useGameMenu';
@@ -30,10 +30,11 @@ export function HUD({ quiz, gameMenu }: HUDProps) {
   const handleTouchMove = useCallback((e: React.TouchEvent) => {
     if (touchStartY.current === null) return;
     const diff = e.touches[0].clientY - touchStartY.current;
-    if (diff < -40 && !hidden) {
+    // Bottom HUD: swipe down to hide, swipe up to show
+    if (diff > 40 && !hidden) {
       setHidden(true);
       touchStartY.current = null;
-    } else if (diff > 40 && hidden) {
+    } else if (diff < -40 && hidden) {
       setHidden(false);
       touchStartY.current = null;
     }
@@ -55,7 +56,7 @@ export function HUD({ quiz, gameMenu }: HUDProps) {
       {/* Hidden indicator — tap or swipe up to show */}
       {hidden && (
         <div
-          className="fixed top-0 left-0 right-0 z-40 flex justify-center pt-1"
+          className="fixed bottom-0 left-0 right-0 z-40 flex justify-center pb-1"
           onClick={() => setHidden(false)}
           onTouchStart={handleTouchStart}
           onTouchMove={handleTouchMove}
@@ -68,9 +69,9 @@ export function HUD({ quiz, gameMenu }: HUDProps) {
       <div
         ref={hudRef}
         className={`
-          fixed top-3 left-1/2 -translate-x-1/2 z-50
+          fixed bottom-3 left-1/2 -translate-x-1/2 z-50
           transition-transform duration-300 ease-out
-          ${hidden ? '-translate-y-[calc(100%+24px)]' : 'translate-y-0'}
+          ${hidden ? 'translate-y-[calc(100%+24px)]' : 'translate-y-0'}
         `}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
@@ -105,6 +106,18 @@ export function HUD({ quiz, gameMenu }: HUDProps) {
               className="w-8 h-8 rounded-xl bg-slate-100/80 text-slate-600 hover:bg-slate-200 dark:bg-slate-800/80 dark:text-slate-300 dark:hover:bg-slate-700"
             >
               <BarChart3 className="w-4 h-4" />
+            </Button>
+          )}
+
+          {currentView !== 'quiz' && isQuizActive && (
+            <Button
+              onClick={() => quiz.goToView('quiz')}
+              variant="ghost"
+              size="icon"
+              aria-label="Quiz fortsetzen"
+              className="w-8 h-8 rounded-xl bg-slate-100/80 text-teal-600 hover:bg-teal-100 hover:text-teal-700 dark:bg-slate-800/80 dark:text-teal-400 dark:hover:bg-teal-900/50"
+            >
+              <Play className="w-4 h-4 fill-current" />
             </Button>
           )}
 

--- a/src/components/game-menu/MenuPageRoot.tsx
+++ b/src/components/game-menu/MenuPageRoot.tsx
@@ -42,6 +42,7 @@ export function MenuPageRoot({ onPush, onClose, quiz }: MenuPageRootProps) {
 
   const handleContinueQuiz = () => {
     if (quiz.isActive) {
+      quiz.goToView('quiz');
       onClose();
     }
   };

--- a/src/test/gameMenuComponents.test.tsx
+++ b/src/test/gameMenuComponents.test.tsx
@@ -93,6 +93,7 @@ describe('HUD', () => {
     render(<HUD quiz={quiz} gameMenu={gameMenu} />);
 
     expect(screen.queryByLabelText('Fortschritt')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Quiz fortsetzen')).toBeInTheDocument();
   });
 
   it('does not render stop button or status when quiz is not active', () => {
@@ -140,11 +141,11 @@ describe('HUD', () => {
     const gameMenu = createMockGameMenu();
 
     const { container } = render(<HUD quiz={quiz} gameMenu={gameMenu} />);
-    const hudBar = container.querySelector('[class*="fixed top-3"]');
+    const hudBar = container.querySelector('[class*="fixed bottom-3"]');
 
     expect(() => {
       fireEvent.touchStart(hudBar!, { touches: [{ clientY: 100 }] });
-      fireEvent.touchMove(hudBar!, { touches: [{ clientY: 50 }] });
+      fireEvent.touchMove(hudBar!, { touches: [{ clientY: 150 }] });
     }).not.toThrow();
   });
 
@@ -153,21 +154,21 @@ describe('HUD', () => {
     const gameMenu = createMockGameMenu();
 
     const { container } = render(<HUD quiz={quiz} gameMenu={gameMenu} />);
-    const hudBar = container.querySelector('[class*="fixed top-3"]') as HTMLElement;
+    const hudBar = container.querySelector('[class*="fixed bottom-3"]') as HTMLElement;
 
-    expect(hudBar.className).not.toContain('-translate-y-[calc(100%+24px)]');
+    expect(hudBar.className).not.toContain('translate-y-[calc(100%+24px)]');
 
     act(() => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'h' }));
     });
 
-    expect(hudBar.className).toContain('-translate-y-[calc(100%+24px)]');
+    expect(hudBar.className).toContain('translate-y-[calc(100%+24px)]');
 
     act(() => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'H' }));
     });
 
-    expect(hudBar.className).not.toContain('-translate-y-[calc(100%+24px)]');
+    expect(hudBar.className).not.toContain('translate-y-[calc(100%+24px)]');
   });
 });
 

--- a/src/views/FlashcardView.tsx
+++ b/src/views/FlashcardView.tsx
@@ -115,7 +115,7 @@ export default function FlashcardView({ quiz, onOpenRunActions, gameMenuOpen }: 
   return (
     <TooltipProvider delayDuration={800}>
       <div className="min-h-screen bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-blue-950 dark:via-slate-900 dark:to-teal-950">
-        <div className="container mx-auto px-3 sm:px-4 py-3 sm:py-4 max-w-4xl pt-14 sm:pt-16">
+        <div className="container mx-auto px-3 sm:px-4 py-3 sm:py-4 max-w-4xl pb-16">
           <QuizHeader
             gameMode={gameMode}
             korrekt={korrekt}

--- a/src/views/HistoryView.tsx
+++ b/src/views/HistoryView.tsx
@@ -59,7 +59,7 @@ export default function HistoryView({ quiz, onBack }: Props) {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-blue-950 dark:via-slate-900 dark:to-teal-950">
-      <div className="container mx-auto px-3 sm:px-4 py-4 sm:py-5 max-w-3xl pt-14 sm:pt-16">
+      <div className="container mx-auto px-3 sm:px-4 py-4 sm:py-5 max-w-3xl pb-16">
         {/* Header */}
         <div className="flex items-center gap-2 mb-4">
           <Button

--- a/src/views/ProgressView.tsx
+++ b/src/views/ProgressView.tsx
@@ -1,8 +1,7 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
-import { Button } from '@/components/ui/button';
-import { CheckCircle, XCircle, HelpCircle, ChevronDown, ArrowLeft, Play } from 'lucide-react';
+import { CheckCircle, XCircle, HelpCircle, ChevronDown } from 'lucide-react';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import type { QuizContext } from '@/hooks/useQuiz';
 
@@ -57,7 +56,7 @@ export default function ProgressView({ quiz }: Props) {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-blue-950 dark:via-slate-900 dark:to-teal-950">
-      <div className="container mx-auto px-3 sm:px-4 py-3 max-w-3xl pt-14 sm:pt-16">
+      <div className="container mx-auto px-3 sm:px-4 py-3 max-w-3xl pb-16">
 
         {/* Run-Ergebnis */}
         <Card className={`mb-2 ${passed ? 'bg-emerald-50 border-emerald-300/50 dark:bg-emerald-900/20 dark:border-emerald-500/30' : 'bg-red-50 border-red-300/50 dark:bg-red-900/20 dark:border-red-500/30'}`}>
@@ -178,33 +177,6 @@ export default function ProgressView({ quiz }: Props) {
                )}
              </CardContent>
            </Card>
-
-        {/* Continue Quiz Button */}
-        {isActive && (
-          <div className="sticky bottom-4 flex justify-center">
-            <Button
-              onClick={() => goToView('quiz')}
-              className="bg-teal-500 hover:bg-teal-600 text-white font-semibold px-6 py-5 text-sm rounded-xl shadow-lg shadow-teal-500/20 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
-            >
-              <Play className="w-4 h-4 mr-2" />
-              Quiz fortsetzen
-            </Button>
-          </div>
-        )}
-
-        {/* Back to Start */}
-        {!isActive && (
-          <div className="flex justify-center mt-4">
-            <Button
-              variant="outline"
-              onClick={() => goToView('start')}
-              className="rounded-xl border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
-            >
-              <ArrowLeft className="w-4 h-4 mr-2" />
-              Zurück zur Startseite
-            </Button>
-          </div>
-        )}
        </div>
      </div>
    );

--- a/src/views/QuizView.tsx
+++ b/src/views/QuizView.tsx
@@ -196,7 +196,7 @@ export default function QuizView({ quiz, onOpenRunActions, gameMenuOpen }: Props
   return (
     <TooltipProvider delayDuration={800}>
       <div className="min-h-screen bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-blue-950 dark:via-slate-900 dark:to-teal-950">
-        <div className="container mx-auto px-3 sm:px-4 py-3 sm:py-4 max-w-4xl pt-14 sm:pt-16">
+        <div className="container mx-auto px-3 sm:px-4 py-3 sm:py-4 max-w-4xl pb-16">
           <QuizHeader
             gameMode={gameMode}
             korrekt={korrekt}

--- a/src/views/StartView.tsx
+++ b/src/views/StartView.tsx
@@ -161,7 +161,7 @@ export default function StartView({ quiz }: Props) {
         <div className="container mx-auto px-3 sm:px-4 py-4 sm:py-5 max-w-3xl">
 
           {/* Header */}
-          <div className="text-center mb-5 sm:mb-6 pt-12 sm:pt-14">
+          <div className="text-center mb-5 sm:mb-6 pt-4 sm:pt-6">
             <div className="flex items-center justify-center gap-2 mb-2">
               <Fish className="w-7 h-7 sm:w-8 sm:h-8 text-teal-400" aria-hidden="true" />
               <h1 className="text-xl sm:text-2xl md:text-3xl font-bold text-slate-900 dark:text-white">Fisherman's Quiz</h1>


### PR DESCRIPTION
Follow-up to #189 / #190

## Changes

### HUD moved to bottom
- HUD is now `fixed bottom-3` instead of `fixed top-3`
- Hidden indicator moved to bottom edge
- Swipe direction updated: swipe down to hide, swipe up to show
- All views adjusted: removed top padding `pt-14`, added bottom padding `pb-16`

### Continue quiz in HUD
- When a quiz is active but the current view is NOT 'quiz' (e.g. ProgressView, StartView), the HUD now shows a **Play button** that jumps directly back into the quiz
- Removed the sticky bottom "Quiz fortsetzen" button from ProgressView

### Menu "Quiz fortsetzen" fixed
- `MenuPageRoot.handleContinueQuiz` now calls `quiz.goToView('quiz')` before closing the menu, so it actually returns to the quiz regardless of which view the menu was opened from

### Mobile drawer Data page
- Removed `snapPoints={[0.5, 0.85]}` from the mobile Vaul drawer so it expands to fit content automatically (capped at `max-h-[85vh]`)
- This fixes the "Daten" section being cut off on mobile

### Tests
- Updated HUD tests for bottom positioning and new translate class
- Added test for continue-quiz button rendering on non-quiz views

## Verification

- [x] `npm run lint` — clean
- [x] `npm run test:run` — 192/192 green
- [x] `npm run build` — clean
