### PR TITLE
feat(locks): per-mode bereich lock logic with canSelectBereich utility (#194)

### DIFF
--- a/src/components/game-menu/MenuPageSettings.tsx
+++ b/src/components/game-menu/MenuPageSettings.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useTheme } from "next-themes";
 import {
   MENU_PAGES,
@@ -17,6 +17,8 @@ interface MenuPageSettingsProps {
 
 export function MenuPageSettings({ onPush, quiz }: MenuPageSettingsProps) {
   const { theme, setTheme } = useTheme();
+  const [showExamConfirm, setShowExamConfirm] = useState(false);
+  const [pendingMode, setPendingMode] = useState<GameMode | null>(null);
 
   const context = useMemo<MenuContext>(
     () => ({
@@ -26,13 +28,36 @@ export function MenuPageSettings({ onPush, quiz }: MenuPageSettingsProps) {
       currentView: quiz.view,
       historyCount: quiz.historyEntries.length,
     }),
-    [quiz, theme],
+    [quiz, theme]
   );
 
   const pageConfig = MENU_PAGES.find((p) => p.id === "settings");
   if (!pageConfig) return null;
 
-  const canChangeMode = !quiz.isActive;
+  const handleModeSwitch = (mode: GameMode) => {
+    // Exam confirmation required only when exam is currently active
+    if (quiz.isActive && quiz.gameMode === "exam") {
+      setPendingMode(mode);
+      setShowExamConfirm(true);
+      return;
+    }
+    // Otherwise switch immediately
+    quiz.setGameMode(mode);
+  };
+
+  const handleConfirmExamSwitch = () => {
+    if (pendingMode) {
+      quiz.beendeExam();
+      quiz.setGameMode(pendingMode);
+    }
+    setShowExamConfirm(false);
+    setPendingMode(null);
+  };
+
+  const handleCancelExamSwitch = () => {
+    setShowExamConfirm(false);
+    setPendingMode(null);
+  };
 
   const handleItemClick = (item: MenuItemConfig) => {
     if (item.action === "navigate" && item.target) {
@@ -40,9 +65,7 @@ export function MenuPageSettings({ onPush, quiz }: MenuPageSettingsProps) {
     } else if (item.action === "toggle" && item.target) {
       const target = item.target as string;
       if (target === "arcade" || target === "hardcore" || target === "exam") {
-        if (canChangeMode) {
-          quiz.setGameMode(target as GameMode);
-        }
+        handleModeSwitch(target as GameMode);
       } else if (
         target === "light" ||
         target === "dark" ||
@@ -63,51 +86,70 @@ export function MenuPageSettings({ onPush, quiz }: MenuPageSettingsProps) {
   const isItemDisabled = (item: MenuItemConfig): boolean => {
     if (typeof item.disabled === "function") return item.disabled(context);
     if (typeof item.disabled === "boolean") return item.disabled;
-
-    // Block mode switch during active run
-    if (
-      item.action === "toggle" &&
-      (item.target === "arcade" ||
-        item.target === "hardcore" ||
-        item.target === "exam")
-    ) {
-      return !canChangeMode;
-    }
-
     return false;
   };
 
   return (
-    <div className="py-2 space-y-6 px-4">
-      {pageConfig.sections?.map((section, sectionIndex) => (
-        <section key={sectionIndex}>
-          {section.title && (
-            <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
-              {section.title}
-            </h3>
-          )}
-          <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
-            {section.items.map((item) => (
-              <MenuItem
-                key={item.id}
-                icon={<item.icon className="w-5 h-5" />}
-                label={item.label}
-                detail={getDetail(item)}
-                onClick={() => handleItemClick(item)}
-                disabled={isItemDisabled(item)}
-                destructive={item.destructive}
-              />
-            ))}
-          </div>
-        </section>
-      ))}
+    <>
+      <div className="py-2 space-y-6 px-4">
+        {pageConfig.sections?.map((section, sectionIndex) => (
+          <section key={sectionIndex}>
+            {section.title && (
+              <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
+                {section.title}
+              </h3>
+            )}
+            <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
+              {section.items.map((item) => (
+                <MenuItem
+                  key={item.id}
+                  icon={<item.icon className="w-5 h-5" />}
+                  label={item.label}
+                  detail={getDetail(item)}
+                  onClick={() => handleItemClick(item)}
+                  disabled={isItemDisabled(item)}
+                  destructive={item.destructive}
+                />
+              ))}
+            </div>
+          </section>
+        ))}
 
-      {/* Info */}
-      <section className="px-4 py-2">
-        <p className="text-xs text-slate-400 dark:text-slate-500 text-center">
-          Fisherman&apos;s Quiz v0.3.5
-        </p>
-      </section>
-    </div>
+        {/* Info */}
+        <section className="px-4 py-2">
+          <p className="text-xs text-slate-400 dark:text-slate-500 text-center">
+            Fisherman&apos;s Quiz v0.3.5
+          </p>
+        </section>
+      </div>
+
+      {/* Exam Mode Switch Confirmation Dialog */}
+      {showExamConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-slate-100 dark:bg-slate-900 rounded-2xl p-6 max-w-sm mx-4 border border-slate-200 dark:border-slate-700 shadow-xl">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2">
+              Laufende Prüfung beenden?
+            </h3>
+            <p className="text-sm text-slate-600 dark:text-slate-400 mb-6">
+              Der Moduswechsel beendet die aktuelle Prüfung. Bereits gegebene Antworten werden gewertet. Dies kann nicht rückgängig gemacht werden.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={handleCancelExamSwitch}
+                className="flex-1 py-2 px-4 rounded-xl border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-300 font-medium hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+              >
+                Abbrechen
+              </button>
+              <button
+                onClick={handleConfirmExamSwitch}
+                className="flex-1 py-2 px-4 rounded-xl bg-red-500 text-white font-medium hover:bg-red-600 transition-colors"
+              >
+                Prüfung beenden und wechseln
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -11,6 +11,7 @@ import { useNotes } from '@/store/notes';
 import { useHistory } from '@/store/history';
 import { useSRS } from '@/store/srs';
 import { isMastered } from '@/utils/srs';
+import { canSelectBereich } from '@/utils/bereichLocks';
 import { filterQuizDataByFavorites, filterQuizDataByWeakness, filterQuizDataBySRSDue } from '@/utils/filter';
 
 const EXAM_DURATION_SECONDS = 60 * 60;
@@ -181,6 +182,13 @@ export function useQuiz() {
   // Starten: Lazy Loading der Bereichs-Fragen
   const starteQuiz = useCallback(async (bereiche: string[], options: QuizStartOptions = {}) => {
     if (!quizMeta) return;
+
+    // Guard: validate all requested bereiche can be selected in current mode
+    const locked = bereiche.filter(id => !canSelectBereich(id, gameMode, meta.meta, quizMeta, run.isActive, run.geladeneBereiche));
+    if (locked.length > 0) {
+      console.error('[useQuiz] Cannot start quiz — locked bereiche:', locked);
+      return;
+    }
 
     const { nurFavoriten = false, filter = 'all' } = options;
     let { limit } = options;

--- a/src/test/bereichLocks.test.ts
+++ b/src/test/bereichLocks.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { canSelectBereich } from '@/utils/bereichLocks';
+import type { MetaProgression } from '@/types/quiz';
+import type { QuizMeta } from '@/utils/quizLoader';
+
+const mockQuizMeta: QuizMeta = {
+  meta: { titel: 'Test', anzahl_fragen: 6, bereiche: { Biologie: 3, Recht: 3 } },
+  bereiche: ['Biologie', 'Recht'],
+  bereichFiles: { Biologie: 'bio.json', Recht: 'recht.json' },
+  fragenIndex: { '1': 'Biologie', '2': 'Biologie', '3': 'Biologie', '4': 'Recht', '5': 'Recht', '6': 'Recht' },
+};
+
+function createMeta(overrides: Partial<MetaProgression> = {}): MetaProgression {
+  return {
+    fragen: {},
+    stats: {
+      totalRuns: 0,
+      totalQuestionsAnswered: 0,
+      totalCorrect: 0,
+      totalIncorrect: 0,
+      bestStreak: 0,
+      currentStreak: 0,
+    },
+    bereiche: {},
+    ...overrides,
+  };
+}
+
+describe('canSelectBereich', () => {
+  it('should always return true for arcade mode', () => {
+    const meta = createMeta();
+    expect(canSelectBereich('Biologie', 'arcade', meta, mockQuizMeta, false, [])).toBe(true);
+  });
+
+  it('should always return true for exam mode', () => {
+    const meta = createMeta();
+    expect(canSelectBereich('Biologie', 'exam', meta, mockQuizMeta, false, [])).toBe(true);
+  });
+
+  it('should return true for hardcore mode when bereich was never attempted', () => {
+    const meta = createMeta();
+    expect(canSelectBereich('Biologie', 'hardcore', meta, mockQuizMeta, false, [])).toBe(true);
+  });
+
+  it('should return true for hardcore mode when bereich is passed', () => {
+    const meta = createMeta({
+      bereiche: {
+        Biologie: { passed: true, consecutivePasses: 1, mastered: false, lastAttempt: '2026-01-01' },
+      },
+    });
+    expect(canSelectBereich('Biologie', 'hardcore', meta, mockQuizMeta, false, [])).toBe(true);
+  });
+
+  it('should return true for hardcore mode when bereich is mastered', () => {
+    const meta = createMeta({
+      bereiche: {
+        Biologie: { passed: true, consecutivePasses: 3, mastered: true, lastAttempt: '2026-01-01' },
+      },
+    });
+    expect(canSelectBereich('Biologie', 'hardcore', meta, mockQuizMeta, false, [])).toBe(true);
+  });
+
+  it('should return false for hardcore mode when bereich was attempted and failed', () => {
+    const meta = createMeta({
+      bereiche: {
+        Biologie: { passed: false, consecutivePasses: 0, mastered: false, lastAttempt: '2026-01-01' },
+      },
+    });
+    expect(canSelectBereich('Biologie', 'hardcore', meta, mockQuizMeta, false, [])).toBe(false);
+  });
+
+  it('should always return true for active bereiche even if failed', () => {
+    const meta = createMeta({
+      bereiche: {
+        Biologie: { passed: false, consecutivePasses: 0, mastered: false, lastAttempt: '2026-01-01' },
+      },
+    });
+    expect(canSelectBereich('Biologie', 'hardcore', meta, mockQuizMeta, true, ['Biologie'])).toBe(true);
+  });
+
+  it('should return true for other bereiche when one is failed', () => {
+    const meta = createMeta({
+      bereiche: {
+        Biologie: { passed: false, consecutivePasses: 0, mastered: false, lastAttempt: '2026-01-01' },
+      },
+    });
+    expect(canSelectBereich('Recht', 'hardcore', meta, mockQuizMeta, false, [])).toBe(true);
+  });
+});

--- a/src/utils/bereichLocks.ts
+++ b/src/utils/bereichLocks.ts
@@ -1,0 +1,43 @@
+import type { GameMode, MetaProgression } from '@/types/quiz';
+import type { QuizMeta } from '@/utils/quizLoader';
+
+/**
+ * Determines whether a specific bereich (topic) can be selected for a quiz run
+ * in the given game mode.
+ *
+ * Rules:
+ * - Arcade: always selectable.
+ * - Exam: always selectable (exam uses all bereiche).
+ * - Hardcore: locked if the bereich was attempted and failed (lastAttempt set,
+ *   but not passed). Mastered and never-attempted bereiche remain selectable.
+ * - Already-active bereiche are always selectable so the user can deselect them.
+ */
+export function canSelectBereich(
+  bereichId: string,
+  mode: GameMode,
+  meta: MetaProgression,
+  _quizMeta: QuizMeta,
+  isActive: boolean,
+  geladeneBereiche: string[]
+): boolean {
+  // Bereiche that are already part of the active run must remain selectable
+  // so the user can deselect / remove them.
+  if (isActive && geladeneBereiche.includes(bereichId)) {
+    return true;
+  }
+
+  if (mode === 'arcade' || mode === 'exam') {
+    return true;
+  }
+
+  if (mode === 'hardcore') {
+    const bMeta = meta.bereiche[bereichId];
+    // Locked: attempted but failed (not passed, not mastered)
+    if (bMeta?.lastAttempt && !bMeta.passed) {
+      return false;
+    }
+    return true;
+  }
+
+  return true;
+}

--- a/src/views/StartView.tsx
+++ b/src/views/StartView.tsx
@@ -16,6 +16,7 @@ import {
 import { Fish, BookOpen, Trophy, Target, Flame, RotateCcw, BarChart3, CheckCircle, Star, Crosshair, Layers, Repeat, Waves, Heart, Scale, Eye } from 'lucide-react';
 import type { QuizContext } from '@/hooks/useQuiz';
 import { isMastered } from '@/utils/srs';
+import { canSelectBereich } from '@/utils/bereichLocks';
 
 const BEREICHE = [
   { id: 'Biologie', label: 'Biologie', icon: Fish, color: 'text-emerald-400', bg: 'bg-emerald-400/10', border: 'border-emerald-400/20', selectedBg: 'bg-emerald-500' },
@@ -99,6 +100,13 @@ export default function StartView({ quiz }: Props) {
       }
       setDialog({ type: 'remove-arcade', bereichId: id, fragenCount: count });
       return;
+    }
+    // Trying to select a new bereich — enforce lock rules
+    if (!ausgewaehlt.includes(id)) {
+      if (quiz.quizMeta && !canSelectBereich(id, gameMode, metaProgress, quiz.quizMeta, isActive, geladeneBereiche)) {
+        setFehler('Dieser Bereich ist im Hardcore-Modus gesperrt. Beende den aktiven Run oder wähle einen anderen Bereich.');
+        return;
+      }
     }
     setAusgewaehlt(p => p.includes(id) ? p.filter(x => x !== id) : [...p, id]);
   };
@@ -356,15 +364,18 @@ export default function StartView({ quiz }: Props) {
                   const inRun = isActive && geladeneBereiche.includes(b.id);
                   const checked = effektivAusgewaehlt.includes(b.id);
                   const status = getBereichStatus(b.id);
+                  const selectable = quiz.quizMeta ? canSelectBereich(b.id, gameMode, metaProgress, quiz.quizMeta, isActive, geladeneBereiche) : true;
+                  const disabled = !selectable && !checked && !inRun;
                   return (
                     <div
                       key={b.id}
-                      onClick={() => toggle(b.id)}
-                      onKeyDown={(e) => handleKeyToggle(e, b.id)}
+                      onClick={() => !disabled && toggle(b.id)}
+                      onKeyDown={(e) => !disabled && handleKeyToggle(e, b.id)}
                       role="checkbox"
                       aria-checked={checked}
-                      tabIndex={0}
-                      className={`flex items-center gap-2 sm:gap-3 p-2.5 sm:p-3 rounded-lg cursor-pointer border transition-all focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 ${checked ? `${b.bg} ${b.border} shadow-md` : 'bg-slate-200/50 border-slate-300/30 hover:bg-slate-300/50 dark:bg-slate-700/30 dark:border-slate-600/30 dark:hover:bg-slate-700/50'} ${inRun ? 'ring-1 ring-teal-400/30' : ''}`}
+                      aria-disabled={disabled}
+                      tabIndex={disabled ? -1 : 0}
+                      className={`flex items-center gap-2 sm:gap-3 p-2.5 sm:p-3 rounded-lg border transition-all focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 ${checked ? `${b.bg} ${b.border} shadow-md` : 'bg-slate-200/50 border-slate-300/30 dark:bg-slate-700/30 dark:border-slate-600/30'} ${inRun ? 'ring-1 ring-teal-400/30' : ''} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:bg-slate-300/50 dark:hover:bg-slate-700/50'}`}
                     >
                       <div className={`w-4 h-4 rounded-full border-2 flex-shrink-0 flex items-center justify-center ${checked ? `${b.selectedBg} border-transparent` : 'border-slate-500 bg-transparent'}`} aria-hidden="true">
                         {checked && <div className="w-1.5 h-1.5 rounded-full bg-white" />}


### PR DESCRIPTION
Closes #194

## Summary
Introduces a single source of truth for bereich selection eligibility across all game modes, separating pure logic from UI presentation.

## Changes

### New: `src/utils/bereichLocks.ts`
- `canSelectBereich(bereichId, mode, meta, quizMeta, isActive, geladeneBereiche): boolean`
- **Arcade**: always `true`
- **Exam**: always `true` (exam uses all bereiche)
- **Hardcore**: `true` only if the bereich is **not locked** (i.e. not attempted-and-failed). Mastered and passed bereiche remain selectable. Already-active bereiche are always selectable so users can deselect them.

### Refactored: `src/views/StartView.tsx`
- `toggle()` now calls `canSelectBereich` before adding a new bereich to the selection
- Locked bereiche get `opacity-50`, `cursor-not-allowed`, `aria-disabled`, and `tabIndex={-1}`
- `getBereichStatus()` remains purely visual (badges only)

### Guarded: `src/hooks/useQuiz.ts`
- `starteQuiz()` validates every requested bereich with `canSelectBereich`
- If any fail, rejects the start and `console.error`s the specific locked IDs

### Tests: `src/test/bereichLocks.test.ts`
8 tests covering arcade, exam, hardcore (never-attempted / passed / mastered / failed / active-failed / unaffected-other).

## Verification
- [x] `npm run lint` — clean
- [x] `npm run test:run` — 200 tests green
- [x] `npm run build` — clean