### PR TITLE
feat(exam): exam submission shows result, no return after submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## [Unreleased]
 
+### Features
+
+* **exam:** Prüfungsabgabe führt jetzt zum Ergebnis statt auf blank screen
+  * `beendeRun()` im Store setzt `isActive = false` statt Run zu löschen — Daten bleiben für ProgressView erhalten
+  * `beendeExam()` wechselt View aktiv auf `'progress'`
+  * `App.tsx` zeigt ProgressView auch bei `!isQuizActive` wenn `rawRun` existiert
+* **hud:** Fortschritt-Button (`BarChart3`) aus QuizView-Menüleiste entfernt
+* **hud:** Play-Button auf ProgressView im Exam-Modus komplett unterdrückt — kein Zurück nach Abgabe
+* **progress:** "Zur Frage"-Buttons in falschen/unbeantworteten Listen sind `disabled` wenn `!isActive`
+
+### Bug Fixes
+
+* **exam:** Timer-Ablauf und manuelle Abgabe zeigen jetzt konsistent das Ergebnis an
+
 ## [0.3.5](https://github.com/kod0r/fishermans-quiz/compare/v0.3.0...v0.3.5) (2026-04-25)
 
 ### Features

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,7 +132,7 @@ function ViewRenderer({
     );
   }
   if (currentView === 'progress') {
-    if (!isQuizActive) return null;
+    if (!isQuizActive && !quiz.rawRun) return null;
     return <ProgressView quiz={quiz} />;
   }
   if (currentView === 'history') {

--- a/src/components/game-menu/HUD.tsx
+++ b/src/components/game-menu/HUD.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from "react";
-import { Home, Menu, BarChart3, Pause, Play } from "lucide-react";
+import { Home, Menu, Pause, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { QuizContext } from "@/hooks/useQuiz";
 import type { MenuPageId } from "@/hooks/useGameMenu";
@@ -104,19 +104,7 @@ export function HUD({ quiz, gameMenu }: HUDProps) {
             </Button>
           )}
 
-          {currentView === "quiz" && isQuizActive && (
-            <Button
-              onClick={() => quiz.goToView("progress")}
-              variant="ghost"
-              size="icon"
-              aria-label="Fortschritt"
-              className="w-8 h-8 rounded-xl bg-slate-100/80 text-teal-500 hover:bg-slate-200 hover:text-teal-600 dark:bg-slate-800/80 dark:text-teal-400 dark:hover:bg-slate-700"
-            >
-              <BarChart3 className="w-4 h-4" />
-            </Button>
-          )}
-
-          {currentView !== "quiz" && isQuizActive && (
+          {currentView !== "quiz" && isQuizActive && quiz.gameMode !== 'exam' && (
             <Button
               onClick={() => quiz.goToView("quiz")}
               variant="ghost"

--- a/src/components/game-menu/MenuPageSettings.tsx
+++ b/src/components/game-menu/MenuPageSettings.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useTheme } from "next-themes";
 import {
   MENU_PAGES,
@@ -17,6 +17,8 @@ interface MenuPageSettingsProps {
 
 export function MenuPageSettings({ onPush, quiz }: MenuPageSettingsProps) {
   const { theme, setTheme } = useTheme();
+  const [showExamConfirm, setShowExamConfirm] = useState(false);
+  const [pendingMode, setPendingMode] = useState<GameMode | null>(null);
 
   const context = useMemo<MenuContext>(
     () => ({
@@ -26,13 +28,36 @@ export function MenuPageSettings({ onPush, quiz }: MenuPageSettingsProps) {
       currentView: quiz.view,
       historyCount: quiz.historyEntries.length,
     }),
-    [quiz, theme],
+    [quiz, theme]
   );
 
   const pageConfig = MENU_PAGES.find((p) => p.id === "settings");
   if (!pageConfig) return null;
 
-  const canChangeMode = !quiz.isActive;
+  const handleModeSwitch = (mode: GameMode) => {
+    // Exam confirmation required only when exam is currently active
+    if (quiz.isActive && quiz.gameMode === "exam") {
+      setPendingMode(mode);
+      setShowExamConfirm(true);
+      return;
+    }
+    // Otherwise switch immediately
+    quiz.setGameMode(mode);
+  };
+
+  const handleConfirmExamSwitch = () => {
+    if (pendingMode) {
+      quiz.beendeExam();
+      quiz.setGameMode(pendingMode);
+    }
+    setShowExamConfirm(false);
+    setPendingMode(null);
+  };
+
+  const handleCancelExamSwitch = () => {
+    setShowExamConfirm(false);
+    setPendingMode(null);
+  };
 
   const handleItemClick = (item: MenuItemConfig) => {
     if (item.action === "navigate" && item.target) {
@@ -40,9 +65,7 @@ export function MenuPageSettings({ onPush, quiz }: MenuPageSettingsProps) {
     } else if (item.action === "toggle" && item.target) {
       const target = item.target as string;
       if (target === "arcade" || target === "hardcore" || target === "exam") {
-        if (canChangeMode) {
-          quiz.setGameMode(target as GameMode);
-        }
+        handleModeSwitch(target as GameMode);
       } else if (
         target === "light" ||
         target === "dark" ||
@@ -63,51 +86,70 @@ export function MenuPageSettings({ onPush, quiz }: MenuPageSettingsProps) {
   const isItemDisabled = (item: MenuItemConfig): boolean => {
     if (typeof item.disabled === "function") return item.disabled(context);
     if (typeof item.disabled === "boolean") return item.disabled;
-
-    // Block mode switch during active run
-    if (
-      item.action === "toggle" &&
-      (item.target === "arcade" ||
-        item.target === "hardcore" ||
-        item.target === "exam")
-    ) {
-      return !canChangeMode;
-    }
-
     return false;
   };
 
   return (
-    <div className="py-2 space-y-6 px-4">
-      {pageConfig.sections?.map((section, sectionIndex) => (
-        <section key={sectionIndex}>
-          {section.title && (
-            <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
-              {section.title}
-            </h3>
-          )}
-          <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
-            {section.items.map((item) => (
-              <MenuItem
-                key={item.id}
-                icon={<item.icon className="w-5 h-5" />}
-                label={item.label}
-                detail={getDetail(item)}
-                onClick={() => handleItemClick(item)}
-                disabled={isItemDisabled(item)}
-                destructive={item.destructive}
-              />
-            ))}
-          </div>
-        </section>
-      ))}
+    <>
+      <div className="py-2 space-y-6 px-4">
+        {pageConfig.sections?.map((section, sectionIndex) => (
+          <section key={sectionIndex}>
+            {section.title && (
+              <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1 px-4 dark:text-slate-400">
+                {section.title}
+              </h3>
+            )}
+            <div className="bg-slate-100/80 dark:bg-slate-800/50 rounded-xl overflow-hidden divide-y divide-slate-200/50 dark:divide-slate-700/50">
+              {section.items.map((item) => (
+                <MenuItem
+                  key={item.id}
+                  icon={<item.icon className="w-5 h-5" />}
+                  label={item.label}
+                  detail={getDetail(item)}
+                  onClick={() => handleItemClick(item)}
+                  disabled={isItemDisabled(item)}
+                  destructive={item.destructive}
+                />
+              ))}
+            </div>
+          </section>
+        ))}
 
-      {/* Info */}
-      <section className="px-4 py-2">
-        <p className="text-xs text-slate-400 dark:text-slate-500 text-center">
-          Fisherman&apos;s Quiz v0.3.5
-        </p>
-      </section>
-    </div>
+        {/* Info */}
+        <section className="px-4 py-2">
+          <p className="text-xs text-slate-400 dark:text-slate-500 text-center">
+            Fisherman&apos;s Quiz v0.3.5
+          </p>
+        </section>
+      </div>
+
+      {/* Exam Mode Switch Confirmation Dialog */}
+      {showExamConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-slate-100 dark:bg-slate-900 rounded-2xl p-6 max-w-sm mx-4 border border-slate-200 dark:border-slate-700 shadow-xl">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2">
+              Laufende Prüfung beenden?
+            </h3>
+            <p className="text-sm text-slate-600 dark:text-slate-400 mb-6">
+              Der Moduswechsel beendet die aktuelle Prüfung. Bereits gegebene Antworten werden gewertet. Dies kann nicht rückgängig gemacht werden.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={handleCancelExamSwitch}
+                className="flex-1 py-2 px-4 rounded-xl border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-300 font-medium hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+              >
+                Abbrechen
+              </button>
+              <button
+                onClick={handleConfirmExamSwitch}
+                className="flex-1 py-2 px-4 rounded-xl bg-red-500 text-white font-medium hover:bg-red-600 transition-colors"
+              >
+                Prüfung beenden und wechseln
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -289,7 +289,8 @@ export function useQuiz() {
   const beendeExam = useCallback(() => {
     if (!run.isActive || gameMode !== 'exam') return;
     logCurrentRun();
-    run.unterbrecheRun();
+    run.beendeRun();
+    setView('progress');
   }, [run, gameMode, logCurrentRun]);
 
   // Flashcard: Selbstbewertung verarbeiten

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -11,6 +11,7 @@ import { useNotes } from '@/store/notes';
 import { useHistory } from '@/store/history';
 import { useSRS } from '@/store/srs';
 import { isMastered } from '@/utils/srs';
+import { canSelectBereich } from '@/utils/bereichLocks';
 import { filterQuizDataByFavorites, filterQuizDataByWeakness, filterQuizDataBySRSDue } from '@/utils/filter';
 
 const EXAM_DURATION_SECONDS = 60 * 60;
@@ -181,6 +182,13 @@ export function useQuiz() {
   // Starten: Lazy Loading der Bereichs-Fragen
   const starteQuiz = useCallback(async (bereiche: string[], options: QuizStartOptions = {}) => {
     if (!quizMeta) return;
+
+    // Guard: validate all requested bereiche can be selected in current mode
+    const locked = bereiche.filter(id => !canSelectBereich(id, gameMode, meta.meta, quizMeta, run.isActive, run.geladeneBereiche));
+    if (locked.length > 0) {
+      console.error('[useQuiz] Cannot start quiz — locked bereiche:', locked);
+      return;
+    }
 
     const { nurFavoriten = false, filter = 'all' } = options;
     let { limit } = options;

--- a/src/store/quizRun.ts
+++ b/src/store/quizRun.ts
@@ -155,6 +155,13 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode) {
     persistRun(null);
   }, [persistRun]);
 
+  const beendeRun = useCallback(() => {
+    setRun(prev => {
+      if (!prev) return prev;
+      return { ...prev, isActive: false };
+    });
+  }, []);
+
   const restarteRun = useCallback(() => {
     if (!run) return;
     const gemischt = [...run.frageIds];
@@ -255,5 +262,6 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode) {
     springeZuFrage,
     entferneBereich,
     unterbrecheRun,
+    beendeRun,
   };
 }

--- a/src/test/bereichLocks.test.ts
+++ b/src/test/bereichLocks.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { canSelectBereich } from '@/utils/bereichLocks';
+import type { MetaProgression } from '@/types/quiz';
+import type { QuizMeta } from '@/utils/quizLoader';
+
+const mockQuizMeta: QuizMeta = {
+  meta: { titel: 'Test', anzahl_fragen: 6, bereiche: { Biologie: 3, Recht: 3 } },
+  bereiche: ['Biologie', 'Recht'],
+  bereichFiles: { Biologie: 'bio.json', Recht: 'recht.json' },
+  fragenIndex: { '1': 'Biologie', '2': 'Biologie', '3': 'Biologie', '4': 'Recht', '5': 'Recht', '6': 'Recht' },
+};
+
+function createMeta(overrides: Partial<MetaProgression> = {}): MetaProgression {
+  return {
+    fragen: {},
+    stats: {
+      totalRuns: 0,
+      totalQuestionsAnswered: 0,
+      totalCorrect: 0,
+      totalIncorrect: 0,
+      bestStreak: 0,
+      currentStreak: 0,
+    },
+    bereiche: {},
+    ...overrides,
+  };
+}
+
+describe('canSelectBereich', () => {
+  it('should always return true for arcade mode', () => {
+    const meta = createMeta();
+    expect(canSelectBereich('Biologie', 'arcade', meta, mockQuizMeta, false, [])).toBe(true);
+  });
+
+  it('should always return true for exam mode', () => {
+    const meta = createMeta();
+    expect(canSelectBereich('Biologie', 'exam', meta, mockQuizMeta, false, [])).toBe(true);
+  });
+
+  it('should return true for hardcore mode when bereich was never attempted', () => {
+    const meta = createMeta();
+    expect(canSelectBereich('Biologie', 'hardcore', meta, mockQuizMeta, false, [])).toBe(true);
+  });
+
+  it('should return true for hardcore mode when bereich is passed', () => {
+    const meta = createMeta({
+      bereiche: {
+        Biologie: { passed: true, consecutivePasses: 1, mastered: false, lastAttempt: '2026-01-01' },
+      },
+    });
+    expect(canSelectBereich('Biologie', 'hardcore', meta, mockQuizMeta, false, [])).toBe(true);
+  });
+
+  it('should return true for hardcore mode when bereich is mastered', () => {
+    const meta = createMeta({
+      bereiche: {
+        Biologie: { passed: true, consecutivePasses: 3, mastered: true, lastAttempt: '2026-01-01' },
+      },
+    });
+    expect(canSelectBereich('Biologie', 'hardcore', meta, mockQuizMeta, false, [])).toBe(true);
+  });
+
+  it('should return false for hardcore mode when bereich was attempted and failed', () => {
+    const meta = createMeta({
+      bereiche: {
+        Biologie: { passed: false, consecutivePasses: 0, mastered: false, lastAttempt: '2026-01-01' },
+      },
+    });
+    expect(canSelectBereich('Biologie', 'hardcore', meta, mockQuizMeta, false, [])).toBe(false);
+  });
+
+  it('should always return true for active bereiche even if failed', () => {
+    const meta = createMeta({
+      bereiche: {
+        Biologie: { passed: false, consecutivePasses: 0, mastered: false, lastAttempt: '2026-01-01' },
+      },
+    });
+    expect(canSelectBereich('Biologie', 'hardcore', meta, mockQuizMeta, true, ['Biologie'])).toBe(true);
+  });
+
+  it('should return true for other bereiche when one is failed', () => {
+    const meta = createMeta({
+      bereiche: {
+        Biologie: { passed: false, consecutivePasses: 0, mastered: false, lastAttempt: '2026-01-01' },
+      },
+    });
+    expect(canSelectBereich('Recht', 'hardcore', meta, mockQuizMeta, false, [])).toBe(true);
+  });
+});

--- a/src/test/gameMenuComponents.test.tsx
+++ b/src/test/gameMenuComponents.test.tsx
@@ -82,17 +82,15 @@ describe('HUD', () => {
 
     expect(screen.getByLabelText('Zur Startseite')).toBeInTheDocument();
     expect(screen.getByLabelText('Menü öffnen')).toBeInTheDocument();
-    expect(screen.getByLabelText('Fortschritt')).toBeInTheDocument();
     expect(screen.getByLabelText('Pause')).toBeInTheDocument();
   });
 
-  it('does not render progress button when view is not quiz', () => {
+  it('does not render progress or pause buttons when view is progress', () => {
     const quiz = createMockQuiz({ isActive: true, view: 'progress' });
     const gameMenu = createMockGameMenu();
 
     render(<HUD quiz={quiz} gameMenu={gameMenu} />);
 
-    expect(screen.queryByLabelText('Fortschritt')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Pause')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Quiz fortsetzen')).toBeInTheDocument();
   });

--- a/src/utils/bereichLocks.ts
+++ b/src/utils/bereichLocks.ts
@@ -1,0 +1,43 @@
+import type { GameMode, MetaProgression } from '@/types/quiz';
+import type { QuizMeta } from '@/utils/quizLoader';
+
+/**
+ * Determines whether a specific bereich (topic) can be selected for a quiz run
+ * in the given game mode.
+ *
+ * Rules:
+ * - Arcade: always selectable.
+ * - Exam: always selectable (exam uses all bereiche).
+ * - Hardcore: locked if the bereich was attempted and failed (lastAttempt set,
+ *   but not passed). Mastered and never-attempted bereiche remain selectable.
+ * - Already-active bereiche are always selectable so the user can deselect them.
+ */
+export function canSelectBereich(
+  bereichId: string,
+  mode: GameMode,
+  meta: MetaProgression,
+  _quizMeta: QuizMeta,
+  isActive: boolean,
+  geladeneBereiche: string[]
+): boolean {
+  // Bereiche that are already part of the active run must remain selectable
+  // so the user can deselect / remove them.
+  if (isActive && geladeneBereiche.includes(bereichId)) {
+    return true;
+  }
+
+  if (mode === 'arcade' || mode === 'exam') {
+    return true;
+  }
+
+  if (mode === 'hardcore') {
+    const bMeta = meta.bereiche[bereichId];
+    // Locked: attempted but failed (not passed, not mastered)
+    if (bMeta?.lastAttempt && !bMeta.passed) {
+      return false;
+    }
+    return true;
+  }
+
+  return true;
+}

--- a/src/views/ProgressView.tsx
+++ b/src/views/ProgressView.tsx
@@ -122,8 +122,9 @@ export default function ProgressView({ quiz }: Props) {
                         <div className="flex items-start justify-between gap-3 mb-1.5">
                           <p className="text-slate-900 font-medium text-sm leading-snug dark:text-white">{frage.frage}</p>
                           <button
-                            onClick={() => { const idx = aktiveFragen.findIndex(f => f.id === frage.id); if (idx >= 0) { springeZuFrage(idx); goToView('quiz'); } }}
-                            className="text-teal-600 text-xs hover:underline whitespace-nowrap flex-shrink-0 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-teal-400 dark:focus-visible:ring-offset-slate-900 rounded"
+                            onClick={() => { if (!isActive) return; const idx = aktiveFragen.findIndex(f => f.id === frage.id); if (idx >= 0) { springeZuFrage(idx); goToView('quiz'); } }}
+                            disabled={!isActive}
+                            className="text-teal-600 text-xs hover:underline whitespace-nowrap flex-shrink-0 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-teal-400 dark:focus-visible:ring-offset-slate-900 rounded disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:no-underline"
                           >
                             Zur Frage
                           </button>
@@ -165,9 +166,10 @@ export default function ProgressView({ quiz }: Props) {
                     return (
                       <button
                         key={frage.id}
-                        onClick={() => { springeZuFrage(idx); goToView('quiz'); }}
+                        onClick={() => { if (!isActive) return; springeZuFrage(idx); goToView('quiz'); }}
+                        disabled={!isActive}
                         aria-label={`Zu unbeantworteter Frage ${idx + 1} springen`}
-                        className="px-2.5 py-1 rounded-md text-xs font-medium bg-amber-50 text-amber-600 border border-amber-300/50 hover:bg-amber-100 transition-all focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-amber-500/10 dark:text-amber-400 dark:border-amber-500/20 dark:hover:bg-amber-500/20 dark:focus-visible:ring-offset-slate-900"
+                        className="px-2.5 py-1 rounded-md text-xs font-medium bg-amber-50 text-amber-600 border border-amber-300/50 hover:bg-amber-100 transition-all focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-amber-500/10 dark:text-amber-400 dark:border-amber-500/20 dark:hover:bg-amber-500/20 dark:focus-visible:ring-offset-slate-900 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-amber-50 dark:disabled:hover:bg-amber-500/10"
                       >
                         Frage {idx + 1}
                       </button>

--- a/src/views/StartView.tsx
+++ b/src/views/StartView.tsx
@@ -16,6 +16,7 @@ import {
 import { Fish, BookOpen, Trophy, Target, Flame, RotateCcw, BarChart3, CheckCircle, Star, Crosshair, Layers, Repeat, Waves, Heart, Scale, Eye } from 'lucide-react';
 import type { QuizContext } from '@/hooks/useQuiz';
 import { isMastered } from '@/utils/srs';
+import { canSelectBereich } from '@/utils/bereichLocks';
 
 const BEREICHE = [
   { id: 'Biologie', label: 'Biologie', icon: Fish, color: 'text-emerald-400', bg: 'bg-emerald-400/10', border: 'border-emerald-400/20', selectedBg: 'bg-emerald-500' },
@@ -99,6 +100,13 @@ export default function StartView({ quiz }: Props) {
       }
       setDialog({ type: 'remove-arcade', bereichId: id, fragenCount: count });
       return;
+    }
+    // Trying to select a new bereich — enforce lock rules
+    if (!ausgewaehlt.includes(id)) {
+      if (quiz.quizMeta && !canSelectBereich(id, gameMode, metaProgress, quiz.quizMeta, isActive, geladeneBereiche)) {
+        setFehler('Dieser Bereich ist im Hardcore-Modus gesperrt. Beende den aktiven Run oder wähle einen anderen Bereich.');
+        return;
+      }
     }
     setAusgewaehlt(p => p.includes(id) ? p.filter(x => x !== id) : [...p, id]);
   };
@@ -356,15 +364,18 @@ export default function StartView({ quiz }: Props) {
                   const inRun = isActive && geladeneBereiche.includes(b.id);
                   const checked = effektivAusgewaehlt.includes(b.id);
                   const status = getBereichStatus(b.id);
+                  const selectable = quiz.quizMeta ? canSelectBereich(b.id, gameMode, metaProgress, quiz.quizMeta, isActive, geladeneBereiche) : true;
+                  const disabled = !selectable && !checked && !inRun;
                   return (
                     <div
                       key={b.id}
-                      onClick={() => toggle(b.id)}
-                      onKeyDown={(e) => handleKeyToggle(e, b.id)}
+                      onClick={() => !disabled && toggle(b.id)}
+                      onKeyDown={(e) => !disabled && handleKeyToggle(e, b.id)}
                       role="checkbox"
                       aria-checked={checked}
-                      tabIndex={0}
-                      className={`flex items-center gap-2 sm:gap-3 p-2.5 sm:p-3 rounded-lg cursor-pointer border transition-all focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 ${checked ? `${b.bg} ${b.border} shadow-md` : 'bg-slate-200/50 border-slate-300/30 hover:bg-slate-300/50 dark:bg-slate-700/30 dark:border-slate-600/30 dark:hover:bg-slate-700/50'} ${inRun ? 'ring-1 ring-teal-400/30' : ''}`}
+                      aria-disabled={disabled}
+                      tabIndex={disabled ? -1 : 0}
+                      className={`flex items-center gap-2 sm:gap-3 p-2.5 sm:p-3 rounded-lg border transition-all focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 ${checked ? `${b.bg} ${b.border} shadow-md` : 'bg-slate-200/50 border-slate-300/30 dark:bg-slate-700/30 dark:border-slate-600/30'} ${inRun ? 'ring-1 ring-teal-400/30' : ''} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:bg-slate-300/50 dark:hover:bg-slate-700/50'}`}
                     >
                       <div className={`w-4 h-4 rounded-full border-2 flex-shrink-0 flex items-center justify-center ${checked ? `${b.selectedBg} border-transparent` : 'border-slate-500 bg-transparent'}`} aria-hidden="true">
                         {checked && <div className="w-1.5 h-1.5 rounded-full bg-white" />}


### PR DESCRIPTION
## Summary

Implements a proper exam submission flow:

- After submitting an exam (early or timer expiry), the app now shows the ProgressView with results instead of a blank screen.
- Once submitted, users can no longer return to the quiz — the play button is hidden on ProgressView in exam mode, and "Zur Frage" buttons are disabled.
- The progress button (BarChart3) is removed from the HUD on QuizView entirely.

## Changes

- `src/store/quizRun.ts` — new `beendeRun()` sets `isActive = false` (preserves data for ProgressView)
- `src/hooks/useQuiz.ts` — `beendeExam()` switches view to `'progress'` after logging
- `src/App.tsx` — ProgressView renders when `rawRun` exists even if `!isActive`
- `src/components/game-menu/HUD.tsx` — remove progress button, hide play button on exam ProgressView
- `src/views/ProgressView.tsx` — disable question jump buttons when `!isActive`
- `src/test/gameMenuComponents.test.tsx` — update tests for removed progress button
- `CHANGELOG.md` — document changes

## Checklist

- [x] `npm run lint` clean
- [x] `npm run test:run` all green (203 tests)
- [x] `npm run build` clean