### PR TITLE
refactor(store): extract RunEngine pure module from useQuizRun (#266)

### DIFF
--- a/src/engine/runEngine.ts
+++ b/src/engine/runEngine.ts
@@ -1,0 +1,220 @@
+import type { Frage, QuizRun, QuizData, SessionType, SelfAssessmentGrade } from '@/types/quiz';
+import { shuffleAnswers as computeShuffle } from '@/utils/quizShuffle';
+
+export interface CreateRunOptions {
+  limit?: number;
+  durationSeconds?: number;
+  sessionType?: SessionType;
+  enableShuffle?: boolean;
+}
+
+function shuffleArray<T>(arr: T[]): T[] {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+function buildAnswerShuffle(fragen: Frage[]): Record<string, ('A' | 'B' | 'C')[]> {
+  const map: Record<string, ('A' | 'B' | 'C')[]> = {};
+  for (const f of fragen) {
+    const { order } = computeShuffle(f);
+    map[f.id] = order;
+  }
+  return map;
+}
+
+export function createRun(quizData: QuizData, topics: string[], options?: CreateRunOptions): QuizRun {
+  const { limit, durationSeconds, sessionType, enableShuffle } = options ?? {};
+  const gefiltert = quizData.fragen.filter(f => topics.includes(f.topic));
+  const gemischt = shuffleArray(gefiltert);
+  const finalPool = limit && limit > 0 ? gemischt.slice(0, limit) : gemischt;
+
+  let answerShuffle: Record<string, ('A' | 'B' | 'C')[]> | undefined;
+  if (enableShuffle) {
+    answerShuffle = buildAnswerShuffle(finalPool);
+  }
+
+  return {
+    frageIds: finalPool.map(f => f.id),
+    antworten: {},
+    topics,
+    aktuellerIndex: 0,
+    isActive: true,
+    startedAt: new Date().toISOString(),
+    durationSeconds,
+    sessionType: sessionType ?? 'quiz',
+    answerShuffle,
+  };
+}
+
+export function extendRun(
+  run: QuizRun,
+  quizData: QuizData,
+  topics: string[],
+  enableShuffle?: boolean,
+): QuizRun | null {
+  if (run.durationSeconds) return null;
+
+  const combinedTopics = [...new Set([...run.topics, ...topics])];
+  const existingIds = new Set(run.frageIds);
+  const neueFragen = quizData.fragen.filter(f => topics.includes(f.topic) && !existingIds.has(f.id));
+  if (neueFragen.length === 0) return null;
+
+  const gemischt = shuffleArray(neueFragen);
+  const newAnswerShuffle = run.answerShuffle ? { ...run.answerShuffle } : undefined;
+  if (newAnswerShuffle && enableShuffle) {
+    for (const f of gemischt) {
+      const { order } = computeShuffle(f);
+      newAnswerShuffle[f.id] = order;
+    }
+  }
+
+  return {
+    ...run,
+    frageIds: [...run.frageIds, ...gemischt.map(f => f.id)],
+    topics: combinedTopics,
+    startedAt: new Date().toISOString(),
+    completedAt: undefined,
+    answerShuffle: newAnswerShuffle,
+  };
+}
+
+export function answerQuestion(run: QuizRun, frageId: string, antwort: string): QuizRun {
+  if (run.antworten[frageId]) return run;
+  return { ...run, antworten: { ...run.antworten, [frageId]: antwort } };
+}
+
+export function selfAssess(run: QuizRun, frageId: string, grade: SelfAssessmentGrade): QuizRun {
+  return {
+    ...run,
+    selfAssessments: { ...(run.selfAssessments ?? {}), [frageId]: grade },
+  };
+}
+
+export function nextQuestion(run: QuizRun): QuizRun {
+  if (run.aktuellerIndex >= run.frageIds.length - 1) return run;
+  return { ...run, aktuellerIndex: run.aktuellerIndex + 1 };
+}
+
+export function prevQuestion(run: QuizRun): QuizRun {
+  if (run.aktuellerIndex <= 0) return run;
+  return { ...run, aktuellerIndex: run.aktuellerIndex - 1 };
+}
+
+export function jumpToQuestion(run: QuizRun, index: number): QuizRun {
+  if (index < 0 || index >= run.frageIds.length) return run;
+  return { ...run, aktuellerIndex: index };
+}
+
+export function removeTopicFromRun(run: QuizRun, quizData: QuizData, topicId: string): QuizRun | null {
+  const idsToRemove = new Set(quizData.fragen.filter(f => f.topic === topicId).map(f => f.id));
+  const neueFrageIds = run.frageIds.filter(id => !idsToRemove.has(id));
+  const newTopics = run.topics.filter(b => b !== topicId);
+
+  if (neueFrageIds.length === run.frageIds.length && newTopics.length === run.topics.length) {
+    return run;
+  }
+
+  if (neueFrageIds.length === 0) {
+    return null;
+  }
+
+  const neueAntworten: Record<string, string> = {};
+  for (const id of neueFrageIds) {
+    if (run.antworten[id] !== undefined) {
+      neueAntworten[id] = run.antworten[id];
+    }
+  }
+
+  const removedBeforeIndex = run.frageIds
+    .slice(0, run.aktuellerIndex + 1)
+    .filter(id => idsToRemove.has(id)).length;
+
+  const neuerIndex = Math.max(0, run.aktuellerIndex - removedBeforeIndex);
+  const finalIndex = Math.min(neuerIndex, neueFrageIds.length - 1);
+
+  let neueAnswerShuffle = run.answerShuffle ? { ...run.answerShuffle } : undefined;
+  if (neueAnswerShuffle) {
+    for (const id of Array.from(idsToRemove)) {
+      delete neueAnswerShuffle[id];
+    }
+    if (Object.keys(neueAnswerShuffle).length === 0) {
+      neueAnswerShuffle = undefined;
+    }
+  }
+
+  return {
+    ...run,
+    frageIds: neueFrageIds,
+    antworten: neueAntworten,
+    topics: newTopics,
+    aktuellerIndex: finalIndex,
+    answerShuffle: neueAnswerShuffle,
+  };
+}
+
+export function restartRun(run: QuizRun, quizData: QuizData): QuizRun {
+  const gemischt = shuffleArray(run.frageIds);
+
+  let newAnswerShuffle: Record<string, ('A' | 'B' | 'C')[]> | undefined;
+  if (run.answerShuffle) {
+    newAnswerShuffle = {};
+    for (const id of gemischt) {
+      const f = quizData.fragen.find(q => q.id === id);
+      if (f) {
+        const { order } = computeShuffle(f);
+        newAnswerShuffle[id] = order;
+      }
+    }
+  }
+
+  return {
+    ...run,
+    frageIds: gemischt,
+    antworten: {},
+    aktuellerIndex: 0,
+    startedAt: new Date().toISOString(),
+    selfAssessments: {},
+    completedAt: undefined,
+    answerShuffle: newAnswerShuffle,
+  };
+}
+
+export function interruptRun(run: QuizRun): QuizRun {
+  return { ...run, isActive: false };
+}
+
+export function completeRun(run: QuizRun): QuizRun {
+  return { ...run, completedAt: new Date().toISOString() };
+}
+
+export function detectInconsistency(run: QuizRun, quizData: QuizData): string[] {
+  const vorhandeneIds = new Set(quizData.fragen.map(f => f.id));
+  return run.frageIds.filter(id => !vorhandeneIds.has(id));
+}
+
+export function purgeMissingQuestions(run: QuizRun, quizData: QuizData): QuizRun | null {
+  const vorhandeneIds = new Set(quizData.fragen.map(f => f.id));
+  const fehlendeIds = run.frageIds.filter(id => !vorhandeneIds.has(id));
+  if (fehlendeIds.length === 0) return run;
+
+  const bereinigteIds = run.frageIds.filter(id => vorhandeneIds.has(id));
+  if (bereinigteIds.length === 0) return null;
+
+  const bereinigteAntworten: Record<string, string> = {};
+  for (const id of bereinigteIds) {
+    if (run.antworten[id] !== undefined) {
+      bereinigteAntworten[id] = run.antworten[id];
+    }
+  }
+  const bereinigterIndex = Math.min(run.aktuellerIndex, bereinigteIds.length - 1);
+  return {
+    ...run,
+    frageIds: bereinigteIds,
+    antworten: bereinigteAntworten,
+    aktuellerIndex: bereinigterIndex,
+  };
+}

--- a/src/engine/runSelectors.ts
+++ b/src/engine/runSelectors.ts
@@ -1,0 +1,37 @@
+import type { Frage, QuizRun, QuizData } from '@/types/quiz';
+
+export function selectActiveQuestions(run: QuizRun, quizData: QuizData): Frage[] {
+  return run.frageIds
+    .map(id => {
+      const f = quizData.fragen.find(q => q.id === id);
+      if (!f) return undefined;
+      const shuffle = run.answerShuffle?.[f.id];
+      if (shuffle) {
+        const keys: ('A' | 'B' | 'C')[] = ['A', 'B', 'C'];
+        const antworten = {
+          A: f.antworten[shuffle[0]],
+          B: f.antworten[shuffle[1]],
+          C: f.antworten[shuffle[2]],
+        };
+        const richtige_antwort = keys[shuffle.indexOf(f.richtige_antwort)];
+        return { ...f, antworten, richtige_antwort };
+      }
+      return f;
+    })
+    .filter((f): f is Frage => f !== undefined);
+}
+
+export interface RunStatistics {
+  beantwortet: number;
+  korrekt: number;
+  falsch: number;
+  gesamt: number;
+}
+
+export function selectStatistics(run: QuizRun, activeQuestions: Frage[]): RunStatistics {
+  const beantwortet = Object.keys(run.antworten).length;
+  const korrekt = activeQuestions.filter(f => run.antworten[f.id] === f.richtige_antwort).length;
+  const falsch = activeQuestions.filter(f => f.id in run.antworten && run.antworten[f.id] !== f.richtige_antwort).length;
+  const gesamt = activeQuestions.length;
+  return { beantwortet, korrekt, falsch, gesamt };
+}

--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { PersistenceAdapter } from '@/utils/persistence';
+import { localStorageAdapter } from '@/utils/persistence';
+
+export function usePersistentState<T>(
+  key: string,
+  defaultValue: T,
+  adapter: PersistenceAdapter = localStorageAdapter,
+): [T, React.Dispatch<React.SetStateAction<T>>, () => void] {
+  const [state, setState] = useState<T>(() => {
+    const loaded = adapter.load(key);
+    return loaded !== null ? (loaded as T) : defaultValue;
+  });
+  const clearedRef = useRef(false);
+
+  useEffect(() => {
+    if (clearedRef.current) {
+      clearedRef.current = false;
+      return;
+    }
+    adapter.save(key, state);
+  }, [key, state, adapter]);
+
+  const clear = useCallback(() => {
+    clearedRef.current = true;
+    setState(defaultValue);
+    adapter.clear(key);
+  }, [key, adapter, defaultValue]);
+
+  return [state, setState, clear];
+}

--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -29,3 +29,46 @@ export function usePersistentState<T>(
 
   return [state, setState, clear];
 }
+
+export function usePersistentStatePerMode<T>(
+  key: string,
+  defaultValue: T,
+  adapter: PersistenceAdapter = localStorageAdapter,
+  shouldSave?: (state: T) => boolean,
+): [T, React.Dispatch<React.SetStateAction<T>>, () => void] {
+  const [state, setState] = useState<T>(() => {
+    const loaded = adapter.load(key);
+    return loaded !== null ? (loaded as T) : defaultValue;
+  });
+  const clearedRef = useRef(false);
+  const adapterRef = useRef(adapter);
+
+  useEffect(() => {
+    adapterRef.current = adapter;
+  });
+
+  useEffect(() => {
+    const loaded = adapterRef.current.load(key);
+    setState(loaded !== null ? (loaded as T) : defaultValue);
+    clearedRef.current = false;
+  }, [key, defaultValue]);
+
+  useEffect(() => {
+    if (clearedRef.current) {
+      clearedRef.current = false;
+      return;
+    }
+    if (shouldSave && !shouldSave(state)) {
+      return;
+    }
+    adapterRef.current.save(key, state);
+  }, [key, state, shouldSave]);
+
+  const clear = useCallback(() => {
+    clearedRef.current = true;
+    setState(defaultValue);
+    adapterRef.current.clear(key);
+  }, [key, defaultValue]);
+
+  return [state, setState, clear];
+}

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useMemo } from 'react';
 import type { QuizData, AppView, QuizStartOptions, SelfAssessmentGrade, GameMode } from '@/types/quiz';
 import type { QuizMeta } from '@/utils/quizLoader';
 import { loadQuizMeta, buildQuizData, loadAllQuizData, AppBackupSchema } from '@/utils/quizLoader';
-import { MetaStorage, RunStorage, SettingsStorage, FavoritesStorage, NotesStorage, HistoryStorage, SRSStorage } from '@/utils/storage';
+import { metaAdapter, runAdapter } from '@/utils/persistence';
 import { useQuizRun } from '@/store/quizRun';
 import { useMetaProgress } from '@/store/metaProgress';
 import { useSettings } from '@/store/settings';
@@ -39,9 +39,9 @@ export function useQuiz() {
       version: '1' as const,
       exportedAt: new Date().toISOString(),
       settings: settings.settings,
-      metaArcade: MetaStorage.load('arcade'),
-      metaHardcore: MetaStorage.load('hardcore'),
-      metaExam: MetaStorage.load('exam'),
+      metaArcade: metaAdapter.load('fmq:meta:arcade:v2'),
+      metaHardcore: metaAdapter.load('fmq:meta:hardcore:v2'),
+      metaExam: metaAdapter.load('fmq:meta:exam:v2'),
       favorites: fav.favorites,
       notes: notes.notes,
       history: history.entries,
@@ -65,14 +65,14 @@ export function useQuiz() {
       return false;
     }
     const backup = parsed.data;
-    MetaStorage.save('arcade', backup.metaArcade);
-    MetaStorage.save('hardcore', backup.metaHardcore);
-    MetaStorage.save('exam', backup.metaExam);
-    SettingsStorage.save(backup.settings);
-    FavoritesStorage.save(backup.favorites);
-    NotesStorage.save(backup.notes);
-    HistoryStorage.save(backup.history);
-    SRSStorage.save(backup.srs);
+    metaAdapter.save('fmq:meta:arcade:v2', backup.metaArcade);
+    metaAdapter.save('fmq:meta:hardcore:v2', backup.metaHardcore);
+    metaAdapter.save('fmq:meta:exam:v2', backup.metaExam);
+    runAdapter.save('fmq:settings:v1', backup.settings);
+    runAdapter.save('fmq:favorites:v1', backup.favorites);
+    runAdapter.save('fmq:notes:v1', backup.notes);
+    runAdapter.save('fmq:history:v1', backup.history);
+    runAdapter.save('fmq:meta:srs:v1', backup.srs);
     window.location.reload();
     return true;
   }, []);
@@ -135,22 +135,21 @@ export function useQuiz() {
 
   // Nur aktuellen Run löschen (ohne Hardcore-Logging)
   const clearCurrentRun = useCallback(() => {
-    RunStorage.clear(gameMode);
     run.wipeRun?.();
-  }, [run, gameMode]);
+  }, [run]);
 
   // Alle Modi zurücksetzen
   const resetAllMetaProgression = useCallback(() => {
-    MetaStorage.clear('arcade');
-    MetaStorage.clear('hardcore');
-    MetaStorage.clear('exam');
+    metaAdapter.clear('fmq:meta:arcade:v2');
+    metaAdapter.clear('fmq:meta:hardcore:v2');
+    metaAdapter.clear('fmq:meta:exam:v2');
     meta.reset();
   }, [meta]);
 
   const clearAllRuns = useCallback(() => {
-    RunStorage.clear('arcade');
-    RunStorage.clear('hardcore');
-    RunStorage.clear('exam');
+    runAdapter.clear('fmq:run:arcade:v2');
+    runAdapter.clear('fmq:run:hardcore:v2');
+    runAdapter.clear('fmq:run:exam:v2');
     run.wipeRun?.();
   }, [run]);
 
@@ -363,7 +362,7 @@ export function useQuiz() {
         }
         run.unterbrecheRun();
         // Persistenz-Effekt läuft nach gameMode-Wechsel mit falscher Key → manuell sicherstellen
-        try { RunStorage.clear(gameMode); } catch { /* ignore */ }
+        try { runAdapter.clear(`fmq:run:${gameMode}:v2`); } catch { /* ignore */ }
       } else if (gameMode === 'exam') {
         // Exam: Ergebnis loggen und beenden
         logCurrentRun();
@@ -376,9 +375,9 @@ export function useQuiz() {
         run.beendeRun();
         // Persistenz-Effekt läuft nach gameMode-Wechsel mit falscher Key → manuell sicherstellen
         if (endedRun) {
-          try { RunStorage.save(gameMode, endedRun); } catch { /* ignore */ }
+          try { runAdapter.save(`fmq:run:${gameMode}:v2`, endedRun); } catch { /* ignore */ }
         } else {
-          try { RunStorage.clear(gameMode); } catch { /* ignore */ }
+          try { runAdapter.clear(`fmq:run:${gameMode}:v2`); } catch { /* ignore */ }
         }
         if (view === 'quiz') {
           setView('progress');

--- a/src/store/favorites.ts
+++ b/src/store/favorites.ts
@@ -1,8 +1,11 @@
-import { useState, useCallback, useEffect } from 'react';
-import { FavoritesStorage } from '@/utils/storage';
+import { useCallback } from 'react';
+import { usePersistentState } from '@/hooks/usePersistentState';
+import type { PersistenceAdapter } from '@/utils/persistence';
 
-export function useFavorites() {
-  const [favorites, setFavorites] = useState<string[]>(() => FavoritesStorage.load());
+const STORAGE_KEY = 'fmq:favorites:v1';
+
+export function useFavorites(adapter?: PersistenceAdapter) {
+  const [favorites, setFavorites] = usePersistentState<string[]>(STORAGE_KEY, [], adapter);
 
   const toggleFavorite = useCallback((frageId: string) => {
     setFavorites(prev =>
@@ -10,28 +13,19 @@ export function useFavorites() {
         ? prev.filter(id => id !== frageId)
         : [...prev, frageId]
     );
-  }, []);
+  }, [setFavorites]);
 
   const isFavorite = useCallback((frageId: string) => {
     return favorites.includes(frageId);
   }, [favorites]);
 
-  // Persistiere Favoriten bei Änderungen
-  useEffect(() => {
-    try {
-      FavoritesStorage.save(favorites);
-    } catch {
-      // Silently ignore storage errors to avoid blocking UI updates
-    }
-  }, [favorites]);
-
   const resetFavorites = useCallback(() => {
     setFavorites([]);
-  }, []);
+  }, [setFavorites]);
 
   const importFavorites = useCallback((data: string[]) => {
     setFavorites(data);
-  }, []);
+  }, [setFavorites]);
 
   return {
     favorites,

--- a/src/store/history.ts
+++ b/src/store/history.ts
@@ -1,15 +1,19 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import type { HistoryEntry, GameMode } from '@/types/quiz';
-import { HistoryStorage } from '@/utils/storage';
+import { usePersistentState } from '@/hooks/usePersistentState';
+import { createHistoryAdapter } from '@/utils/persistence/historyAdapter';
+import type { PersistenceAdapter } from '@/utils/persistence';
 
-export function useHistory() {
-  const [entries, setEntries] = useState<HistoryEntry[]>(() => {
-    const loaded = HistoryStorage.load();
-    return loaded.map((entry) => ({
-      ...entry,
-      topics: (((entry as unknown as Record<string, unknown>).topics ?? (entry as unknown as Record<string, unknown>).bereiche ?? []) as string[]),
-    }));
-  });
+const STORAGE_KEY = 'fmq:history:v1';
+const MAX_ENTRIES = 500;
+const defaultAdapter = createHistoryAdapter();
+
+export function useHistory(adapter: PersistenceAdapter = defaultAdapter) {
+  const [entries, setEntries] = usePersistentState<HistoryEntry[]>(
+    STORAGE_KEY,
+    [],
+    adapter,
+  );
 
   const addEntry = useCallback((params: {
     topics: string[];
@@ -23,25 +27,16 @@ export function useHistory() {
       timestamp: new Date().toISOString(),
       ...params,
     };
-    setEntries(prev => [entry, ...prev].slice(0, 500));
-  }, []);
+    setEntries(prev => [entry, ...prev].slice(0, MAX_ENTRIES));
+  }, [setEntries]);
 
   const clearHistory = useCallback(() => {
     setEntries([]);
-  }, []);
+  }, [setEntries]);
 
   const importHistory = useCallback((data: HistoryEntry[]) => {
-    setEntries(data);
-  }, []);
-
-  // Persistiere History bei Änderungen
-  useEffect(() => {
-    try {
-      HistoryStorage.save(entries);
-    } catch {
-      // Silently ignore storage errors to avoid blocking UI updates
-    }
-  }, [entries]);
+    setEntries(data.slice(0, MAX_ENTRIES));
+  }, [setEntries]);
 
   return {
     entries,

--- a/src/store/metaProgress.ts
+++ b/src/store/metaProgress.ts
@@ -1,6 +1,8 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { FrageMeta, TopicMeta, MetaProgression, GameMode } from '@/types/quiz';
-import { MetaStorage } from '@/utils/storage';
+import { usePersistentStatePerMode } from '@/hooks/usePersistentState';
+import { createMetaAdapter } from '@/utils/persistence/metaAdapter';
+import type { PersistenceAdapter } from '@/utils/persistence';
 
 const EMPTY: MetaProgression = Object.freeze({
   fragen: {},
@@ -18,23 +20,20 @@ const EMPTY: MetaProgression = Object.freeze({
   bestArcadeScore: {},
 });
 
-export function useMetaProgress(gameMode: GameMode) {
-  const [meta, setMeta] = useState<MetaProgression>(() => {
-    const loaded = MetaStorage.load(gameMode);
-    return { ...loaded, topics: loaded.topics ?? {} };
-  });
+const metaKey = (mode: GameMode) => `fmq:meta:${mode}:v2`;
+const defaultAdapter = createMetaAdapter();
 
-  // Wenn sich der Modus ändert → neu laden
-  useEffect(() => {
-    const loaded = MetaStorage.load(gameMode);
-    setMeta({ ...loaded, topics: loaded.topics ?? {} });
-  }, [gameMode]);
+export function useMetaProgress(gameMode: GameMode, adapter: PersistenceAdapter = defaultAdapter) {
+  const [meta, setMeta] = usePersistentStatePerMode<MetaProgression>(
+    metaKey(gameMode),
+    EMPTY,
+    adapter,
+  );
 
   const persist = useCallback((next: MetaProgression) => {
     setMeta(next);
-  }, []);
+  }, [setMeta]);
 
-  // Einzelne Antwort verarbeiten
   const recordAnswer = useCallback((frageId: string, isCorrect: boolean) => {
     setMeta(prev => {
       const now = new Date().toISOString();
@@ -61,16 +60,14 @@ export function useMetaProgress(gameMode: GameMode) {
 
       return { ...prev, fragen: { ...prev.fragen, [frageId]: frageMeta }, stats };
     });
-  }, []);
+  }, [setMeta]);
 
-  // Neuer Durchlauf gestartet
   const recordRunStart = useCallback(() => {
     setMeta(prev => {
       return { ...prev, stats: { ...prev.stats, totalRuns: prev.stats.totalRuns + 1 } };
     });
-  }, []);
+  }, [setMeta]);
 
-  // Topic-Result speichern (Hardcore)
   const recordTopicResult = useCallback((topicId: string, passed: boolean) => {
     setMeta(prev => {
       const existing = prev.topics[topicId];
@@ -87,7 +84,6 @@ export function useMetaProgress(gameMode: GameMode) {
         [topicId]: topicMeta,
       };
 
-      // Freischalten: bestandenes Thema entsperrt alle gesperrten Themen
       if (passed) {
         for (const [id, tMeta] of Object.entries(nextTopics)) {
           if (
@@ -106,9 +102,8 @@ export function useMetaProgress(gameMode: GameMode) {
         topics: nextTopics,
       };
     });
-  }, []);
+  }, [setMeta]);
 
-  // Exam abschließen
   const recordExamResult = useCallback((scorePct: number, passed: boolean) => {
     setMeta(prev => {
       const prevExam = prev.examMeta;
@@ -122,9 +117,8 @@ export function useMetaProgress(gameMode: GameMode) {
         },
       };
     });
-  }, []);
+  }, [setMeta]);
 
-  // Arcade-Run abschließen — Sterne + Highscore pro Topic
   const recordArcadeRunComplete = useCallback((topicId: string, scorePct: number) => {
     setMeta(prev => {
       const stars: 1 | 2 | 3 = scorePct >= 100 ? 3 : scorePct >= 75 ? 2 : 1;
@@ -147,26 +141,15 @@ export function useMetaProgress(gameMode: GameMode) {
         },
       };
     });
-  }, []);
+  }, [setMeta]);
 
-  // Komplett zurücksetzen
   const reset = useCallback(() => {
     persist(EMPTY);
   }, [persist]);
 
-  // Importieren
   const importData = useCallback((data: MetaProgression) => {
     persist(data);
   }, [persist]);
-
-  // Persistiere Meta bei Änderungen
-  useEffect(() => {
-    try {
-      MetaStorage.save(gameMode, meta);
-    } catch {
-      // Silently ignore storage errors to avoid blocking UI updates
-    }
-  }, [meta, gameMode]);
 
   const passedTopicsHardcore = useMemo(() =>
     Object.values(meta.topics ?? {}).filter(b => b.passed).length,

--- a/src/store/notes.ts
+++ b/src/store/notes.ts
@@ -1,8 +1,11 @@
-import { useState, useCallback, useEffect } from 'react';
-import { NotesStorage } from '@/utils/storage';
+import { useCallback } from 'react';
+import { usePersistentState } from '@/hooks/usePersistentState';
+import type { PersistenceAdapter } from '@/utils/persistence';
 
-export function useNotes() {
-  const [notes, setNotes] = useState<Record<string, string>>(() => NotesStorage.load());
+const STORAGE_KEY = 'fmq:notes:v1';
+
+export function useNotes(adapter?: PersistenceAdapter) {
+  const [notes, setNotes] = usePersistentState<Record<string, string>>(STORAGE_KEY, {}, adapter);
 
   const setNote = useCallback((frageId: string, text: string) => {
     setNotes(prev => {
@@ -15,28 +18,19 @@ export function useNotes() {
       }
       return { ...prev, [frageId]: text.trim() };
     });
-  }, []);
+  }, [setNotes]);
 
   const getNote = useCallback((frageId: string) => {
     return notes[frageId] ?? '';
   }, [notes]);
 
-  // Persistiere Notizen bei Änderungen
-  useEffect(() => {
-    try {
-      NotesStorage.save(notes);
-    } catch {
-      // Silently ignore storage errors to avoid blocking UI updates
-    }
-  }, [notes]);
-
   const resetNotes = useCallback(() => {
     setNotes({});
-  }, []);
+  }, [setNotes]);
 
   const importNotes = useCallback((data: Record<string, string>) => {
     setNotes(data);
-  }, []);
+  }, [setNotes]);
 
   return {
     notes,

--- a/src/store/quizRun.ts
+++ b/src/store/quizRun.ts
@@ -1,31 +1,66 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import type { Frage, QuizRun, QuizData, GameMode, SessionType, SelfAssessmentGrade } from '@/types/quiz';
 import { shuffleAnswers as computeShuffle } from '@/utils/quizShuffle';
-import { RunStorage } from '@/utils/storage';
+import { usePersistentStatePerMode } from '@/hooks/usePersistentState';
+import type { PersistenceAdapter } from '@/utils/persistence';
 
-export function useQuizRun(quizData: QuizData | null, gameMode: GameMode) {
-  const [run, setRun] = useState<QuizRun | null>(() => RunStorage.load(gameMode));
+const runKey = (mode: GameMode) => `fmq:run:${mode}:v2`;
 
-  // Wenn sich der Modus ändert → neu laden
-  useEffect(() => {
-    setRun(RunStorage.load(gameMode));
+export function useQuizRun(quizData: QuizData | null, gameMode: GameMode, adapter?: PersistenceAdapter) {
+  const shouldSave = useCallback((run: QuizRun | null) => {
+    if (run && run.gameMode && run.gameMode !== gameMode) return false;
+    return true;
   }, [gameMode]);
 
-  // Persistiere Run bei Änderungen
+  const [run, setRun] = usePersistentStatePerMode<QuizRun | null>(
+    runKey(gameMode),
+    null,
+    adapter,
+    shouldSave,
+  );
+
+  // Daten-Inkonsistenz erkennen und bereinigen (Issue #17)
+  useEffect(() => {
+    if (!run || !quizData) return;
+
+    const vorhandeneIds = new Set(quizData.fragen.map(f => f.id));
+    const fehlendeIds = run.frageIds.filter(id => !vorhandeneIds.has(id));
+
+    if (fehlendeIds.length > 0) {
+      console.warn(`[quizRun] ${fehlendeIds.length} Frage(n) aus dem Run nicht mehr im Katalog vorhanden. Bereinige...`, fehlendeIds);
+      const bereinigteIds = run.frageIds.filter(id => vorhandeneIds.has(id));
+      if (bereinigteIds.length === 0) {
+        setRun(null);
+        return;
+      }
+      const bereinigteAntworten: Record<string, string> = {};
+      for (const id of bereinigteIds) {
+        if (run.antworten[id] !== undefined) {
+          bereinigteAntworten[id] = run.antworten[id];
+        }
+      }
+      const bereinigterIndex = Math.min(run.aktuellerIndex, bereinigteIds.length - 1);
+      setRun({
+        ...run,
+        frageIds: bereinigteIds,
+        antworten: bereinigteAntworten,
+        aktuellerIndex: bereinigterIndex,
+        gameMode: run.gameMode ?? gameMode,
+      });
+    }
+  }, [run, quizData, setRun, gameMode]);
+
   const persistRun = useCallback((next: QuizRun | null) => {
     setRun(next);
-  }, []);
+  }, [setRun]);
 
-  // Starte neuen Run oder erweitere bestehenden
   const starteRun = useCallback((topics: string[], overrideData?: QuizData, limit?: number, durationSeconds?: number, sessionType?: SessionType, enableShuffle?: boolean) => {
     const qd = overrideData || quizData;
     if (!qd) return;
 
     if (run?.isActive) {
-      // Zeitbegrenzte Runs können nicht erweitert werden
       if (run.durationSeconds) return;
 
-      // Erweitere bestehenden Run
       const combinedTopics = [...new Set([...run.topics, ...topics])];
       const existingIds = new Set(run.frageIds);
       const neueFragen = qd.fragen.filter(
@@ -33,7 +68,6 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode) {
       );
       if (neueFragen.length === 0) return;
 
-      // Fisher-Yates Shuffle
       const gemischt = [...neueFragen];
       for (let i = gemischt.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
@@ -58,7 +92,6 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode) {
         gameMode: run.gameMode ?? gameMode,
       });
     } else {
-      // Neuer Run
       const gefiltert = qd.fragen.filter(f => topics.includes(f.topic));
       const gemischt = [...gefiltert];
       for (let i = gemischt.length - 1; i > 0; i--) {
@@ -66,7 +99,6 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode) {
         [gemischt[i], gemischt[j]] = [gemischt[j], gemischt[i]];
       }
 
-      // Limit erst nach dem Shuffle anwenden, damit die Subset-Auswahl zufällig ist
       const finalPool = limit && limit > 0 ? gemischt.slice(0, limit) : gemischt;
 
       let answerShuffle: Record<string, ('A' | 'B' | 'C')[]> | undefined;
@@ -93,15 +125,13 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode) {
     }
   }, [quizData, run, persistRun, gameMode]);
 
-  // Antwort speichern (nur wenn noch nicht beantwortet)
   const beantworteFrage = useCallback((frageId: string, antwort: string) => {
     setRun(prev => {
       if (!prev || prev.antworten[frageId]) return prev;
       return { ...prev, antworten: { ...prev.antworten, [frageId]: antwort } };
     });
-  }, []);
+  }, [setRun]);
 
-  // Selbstbewertung speichern (Flashcard Mode)
   const bewerteSelbst = useCallback((frageId: string, grade: SelfAssessmentGrade) => {
     setRun(prev => {
       if (!prev) return prev;
@@ -110,28 +140,28 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode) {
         selfAssessments: { ...(prev.selfAssessments ?? {}), [frageId]: grade },
       };
     });
-  }, []);
+  }, [setRun]);
 
   const naechsteFrage = useCallback(() => {
     setRun(prev => {
       if (!prev || prev.aktuellerIndex >= prev.frageIds.length - 1) return prev;
       return { ...prev, aktuellerIndex: prev.aktuellerIndex + 1 };
     });
-  }, []);
+  }, [setRun]);
 
   const vorherigeFrage = useCallback(() => {
     setRun(prev => {
       if (!prev || prev.aktuellerIndex <= 0) return prev;
       return { ...prev, aktuellerIndex: prev.aktuellerIndex - 1 };
     });
-  }, []);
+  }, [setRun]);
 
   const springeZuFrage = useCallback((index: number) => {
     setRun(prev => {
       if (!prev || index < 0 || index >= prev.frageIds.length) return prev;
       return { ...prev, aktuellerIndex: index };
     });
-  }, []);
+  }, [setRun]);
 
   const removeTopic = useCallback((topicId: string) => {
     if (!run || !quizData) return;
@@ -188,12 +218,11 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode) {
   }, [run, quizData, persistRun, gameMode]);
 
   const unterbrecheRun = useCallback(() => {
-    // Strategy: mark inactive instead of wiping so answerShuffle survives for review.
     setRun(prev => {
       if (!prev) return prev;
       return { ...prev, isActive: false };
     });
-  }, []);
+  }, [setRun]);
 
   const wipeRun = useCallback(() => {
     persistRun(null);
@@ -204,14 +233,14 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode) {
       if (!prev) return prev;
       return { ...prev, isActive: false };
     });
-  }, []);
+  }, [setRun]);
 
   const markCompleted = useCallback(() => {
     setRun(prev => {
       if (!prev) return prev;
       return { ...prev, completedAt: new Date().toISOString() };
     });
-  }, []);
+  }, [setRun]);
 
   const restarteRun = useCallback(() => {
     if (!run || !quizData) return;
@@ -246,57 +275,6 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode) {
     });
   }, [run, quizData, persistRun, gameMode]);
 
-  // Persistiere Run bei Änderungen
-  useEffect(() => {
-    if (run) {
-      // Verhindert Speichern eines Runs unter dem falschen Modus-Key
-      if (run.gameMode && run.gameMode !== gameMode) return;
-      try {
-        RunStorage.save(gameMode, run);
-      } catch {
-        // Silently ignore storage errors to avoid blocking UI updates
-      }
-    } else {
-      try {
-        RunStorage.clear(gameMode);
-      } catch {
-        // Silently ignore storage errors
-      }
-    }
-  }, [run, gameMode]);
-
-  // Daten-Inkonsistenz erkennen und bereinigen (Issue #17)
-  useEffect(() => {
-    if (!run || !quizData) return;
-
-    const vorhandeneIds = new Set(quizData.fragen.map(f => f.id));
-    const fehlendeIds = run.frageIds.filter(id => !vorhandeneIds.has(id));
-
-    if (fehlendeIds.length > 0) {
-      console.warn(`[quizRun] ${fehlendeIds.length} Frage(n) aus dem Run nicht mehr im Katalog vorhanden. Bereinige...`, fehlendeIds);
-      const bereinigteIds = run.frageIds.filter(id => vorhandeneIds.has(id));
-      if (bereinigteIds.length === 0) {
-        persistRun(null);
-        return;
-      }
-      const bereinigteAntworten: Record<string, string> = {};
-      for (const id of bereinigteIds) {
-        if (run.antworten[id] !== undefined) {
-          bereinigteAntworten[id] = run.antworten[id];
-        }
-      }
-      const bereinigterIndex = Math.min(run.aktuellerIndex, bereinigteIds.length - 1);
-      persistRun({
-        ...run,
-        frageIds: bereinigteIds,
-        antworten: bereinigteAntworten,
-        aktuellerIndex: bereinigterIndex,
-        gameMode: run.gameMode ?? gameMode,
-      });
-    }
-  }, [run, quizData, persistRun, gameMode]);
-
-  // Abgeleitete Daten
   const aktiveFragen = useMemo<Frage[]>(() => {
     if (!run || !quizData) return [];
     return run.frageIds

--- a/src/store/quizRun.ts
+++ b/src/store/quizRun.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import type { Frage, QuizRun, QuizData, GameMode, SessionType, SelfAssessmentGrade } from '@/types/quiz';
-import { shuffleAnswers as computeShuffle } from '@/utils/quizShuffle';
 import { usePersistentStatePerMode } from '@/hooks/usePersistentState';
 import type { PersistenceAdapter } from '@/utils/persistence';
+import * as RunEngine from '@/engine/runEngine';
+import { selectActiveQuestions, selectStatistics } from '@/engine/runSelectors';
 
 const runKey = (mode: GameMode) => `fmq:run:${mode}:v2`;
 
@@ -19,208 +20,88 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode, adapte
     shouldSave,
   );
 
-  // Daten-Inkonsistenz erkennen und bereinigen (Issue #17)
-  useEffect(() => {
-    if (!run || !quizData) return;
-
-    const vorhandeneIds = new Set(quizData.fragen.map(f => f.id));
-    const fehlendeIds = run.frageIds.filter(id => !vorhandeneIds.has(id));
-
-    if (fehlendeIds.length > 0) {
-      console.warn(`[quizRun] ${fehlendeIds.length} Frage(n) aus dem Run nicht mehr im Katalog vorhanden. Bereinige...`, fehlendeIds);
-      const bereinigteIds = run.frageIds.filter(id => vorhandeneIds.has(id));
-      if (bereinigteIds.length === 0) {
-        setRun(null);
-        return;
-      }
-      const bereinigteAntworten: Record<string, string> = {};
-      for (const id of bereinigteIds) {
-        if (run.antworten[id] !== undefined) {
-          bereinigteAntworten[id] = run.antworten[id];
-        }
-      }
-      const bereinigterIndex = Math.min(run.aktuellerIndex, bereinigteIds.length - 1);
-      setRun({
-        ...run,
-        frageIds: bereinigteIds,
-        antworten: bereinigteAntworten,
-        aktuellerIndex: bereinigterIndex,
-        gameMode: run.gameMode ?? gameMode,
-      });
-    }
-  }, [run, quizData, setRun, gameMode]);
-
   const persistRun = useCallback((next: QuizRun | null) => {
     setRun(next);
   }, [setRun]);
+
+  // Daten-Inkonsistenz erkennen und bereinigen (Issue #17)
+  useEffect(() => {
+    if (!run || !quizData) return;
+    const bereinigt = RunEngine.purgeMissingQuestions(run, quizData);
+    if (bereinigt !== run) {
+      const fehlendeIds = RunEngine.detectInconsistency(run, quizData);
+      console.warn(`[quizRun] ${fehlendeIds.length} Frage(n) aus dem Run nicht mehr im Katalog vorhanden. Bereinige...`, fehlendeIds);
+      if (bereinigt === null) {
+        setRun(null);
+      } else {
+        setRun({ ...bereinigt, gameMode: bereinigt.gameMode ?? gameMode });
+      }
+    }
+  }, [run, quizData, setRun, gameMode]);
 
   const starteRun = useCallback((topics: string[], overrideData?: QuizData, limit?: number, durationSeconds?: number, sessionType?: SessionType, enableShuffle?: boolean) => {
     const qd = overrideData || quizData;
     if (!qd) return;
 
     if (run?.isActive) {
-      if (run.durationSeconds) return;
-
-      const combinedTopics = [...new Set([...run.topics, ...topics])];
-      const existingIds = new Set(run.frageIds);
-      const neueFragen = qd.fragen.filter(
-        f => topics.includes(f.topic) && !existingIds.has(f.id)
-      );
-      if (neueFragen.length === 0) return;
-
-      const gemischt = [...neueFragen];
-      for (let i = gemischt.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [gemischt[i], gemischt[j]] = [gemischt[j], gemischt[i]];
-      }
-
-      const newAnswerShuffle = run.answerShuffle ? { ...run.answerShuffle } : undefined;
-      if (newAnswerShuffle && enableShuffle) {
-        for (const f of gemischt) {
-          const { order } = computeShuffle(f);
-          newAnswerShuffle[f.id] = order;
-        }
-      }
-
-      persistRun({
-        ...run,
-        frageIds: [...run.frageIds, ...gemischt.map(f => f.id)],
-        topics: combinedTopics,
-        startedAt: new Date().toISOString(),
-        completedAt: undefined,
-        answerShuffle: newAnswerShuffle,
-        gameMode: run.gameMode ?? gameMode,
-      });
+      const extended = RunEngine.extendRun(run, qd, topics, enableShuffle);
+      if (!extended) return;
+      persistRun({ ...extended, gameMode: extended.gameMode ?? gameMode });
     } else {
-      const gefiltert = qd.fragen.filter(f => topics.includes(f.topic));
-      const gemischt = [...gefiltert];
-      for (let i = gemischt.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [gemischt[i], gemischt[j]] = [gemischt[j], gemischt[i]];
-      }
-
-      const finalPool = limit && limit > 0 ? gemischt.slice(0, limit) : gemischt;
-
-      let answerShuffle: Record<string, ('A' | 'B' | 'C')[]> | undefined;
-      if (enableShuffle) {
-        answerShuffle = {};
-        for (const f of finalPool) {
-          const { order } = computeShuffle(f);
-          answerShuffle[f.id] = order;
-        }
-      }
-
-      persistRun({
-        frageIds: finalPool.map(f => f.id),
-        antworten: {},
-        topics,
-        aktuellerIndex: 0,
-        isActive: true,
-        startedAt: new Date().toISOString(),
-        durationSeconds,
-        sessionType: sessionType ?? 'quiz',
-        answerShuffle,
-        gameMode,
-      });
+      const created = RunEngine.createRun(qd, topics, { limit, durationSeconds, sessionType, enableShuffle });
+      persistRun({ ...created, gameMode });
     }
   }, [quizData, run, persistRun, gameMode]);
 
   const beantworteFrage = useCallback((frageId: string, antwort: string) => {
     setRun(prev => {
-      if (!prev || prev.antworten[frageId]) return prev;
-      return { ...prev, antworten: { ...prev.antworten, [frageId]: antwort } };
+      if (!prev) return prev;
+      return RunEngine.answerQuestion(prev, frageId, antwort);
     });
   }, [setRun]);
 
   const bewerteSelbst = useCallback((frageId: string, grade: SelfAssessmentGrade) => {
     setRun(prev => {
       if (!prev) return prev;
-      return {
-        ...prev,
-        selfAssessments: { ...(prev.selfAssessments ?? {}), [frageId]: grade },
-      };
+      return RunEngine.selfAssess(prev, frageId, grade);
     });
   }, [setRun]);
 
   const naechsteFrage = useCallback(() => {
     setRun(prev => {
-      if (!prev || prev.aktuellerIndex >= prev.frageIds.length - 1) return prev;
-      return { ...prev, aktuellerIndex: prev.aktuellerIndex + 1 };
+      if (!prev) return prev;
+      return RunEngine.nextQuestion(prev);
     });
   }, [setRun]);
 
   const vorherigeFrage = useCallback(() => {
     setRun(prev => {
-      if (!prev || prev.aktuellerIndex <= 0) return prev;
-      return { ...prev, aktuellerIndex: prev.aktuellerIndex - 1 };
+      if (!prev) return prev;
+      return RunEngine.prevQuestion(prev);
     });
   }, [setRun]);
 
   const springeZuFrage = useCallback((index: number) => {
     setRun(prev => {
-      if (!prev || index < 0 || index >= prev.frageIds.length) return prev;
-      return { ...prev, aktuellerIndex: index };
+      if (!prev) return prev;
+      return RunEngine.jumpToQuestion(prev, index);
     });
   }, [setRun]);
 
   const removeTopic = useCallback((topicId: string) => {
     if (!run || !quizData) return;
-
-    const idsToRemove = new Set(
-      quizData.fragen.filter(f => f.topic === topicId).map(f => f.id)
-    );
-
-    const neueFrageIds = run.frageIds.filter(id => !idsToRemove.has(id));
-    const newTopics = run.topics.filter(b => b !== topicId);
-
-    if (neueFrageIds.length === run.frageIds.length && newTopics.length === run.topics.length) {
-      return;
-    }
-
-    if (neueFrageIds.length === 0) {
+    const next = RunEngine.removeTopicFromRun(run, quizData, topicId);
+    if (next === null) {
       persistRun(null);
-      return;
+    } else if (next !== run) {
+      persistRun({ ...next, gameMode: next.gameMode ?? gameMode });
     }
-
-    const neueAntworten: Record<string, string> = {};
-    for (const id of neueFrageIds) {
-      if (run.antworten[id] !== undefined) {
-        neueAntworten[id] = run.antworten[id];
-      }
-    }
-
-    const removedBeforeIndex = run.frageIds
-      .slice(0, run.aktuellerIndex + 1)
-      .filter(id => idsToRemove.has(id)).length;
-
-    const neuerIndex = Math.max(0, run.aktuellerIndex - removedBeforeIndex);
-    const finalIndex = Math.min(neuerIndex, neueFrageIds.length - 1);
-
-    let neueAnswerShuffle = run.answerShuffle ? { ...run.answerShuffle } : undefined;
-    if (neueAnswerShuffle) {
-      for (const id of Array.from(idsToRemove)) {
-        delete neueAnswerShuffle[id];
-      }
-      if (Object.keys(neueAnswerShuffle).length === 0) {
-        neueAnswerShuffle = undefined;
-      }
-    }
-
-    persistRun({
-      ...run,
-      frageIds: neueFrageIds,
-      antworten: neueAntworten,
-      topics: newTopics,
-      aktuellerIndex: finalIndex,
-      answerShuffle: neueAnswerShuffle,
-      gameMode: run.gameMode ?? gameMode,
-    });
   }, [run, quizData, persistRun, gameMode]);
 
   const unterbrecheRun = useCallback(() => {
     setRun(prev => {
       if (!prev) return prev;
-      return { ...prev, isActive: false };
+      return RunEngine.interruptRun(prev);
     });
   }, [setRun]);
 
@@ -231,80 +112,34 @@ export function useQuizRun(quizData: QuizData | null, gameMode: GameMode, adapte
   const beendeRun = useCallback(() => {
     setRun(prev => {
       if (!prev) return prev;
-      return { ...prev, isActive: false };
+      return RunEngine.interruptRun(prev);
     });
   }, [setRun]);
 
   const markCompleted = useCallback(() => {
     setRun(prev => {
       if (!prev) return prev;
-      return { ...prev, completedAt: new Date().toISOString() };
+      return RunEngine.completeRun(prev);
     });
   }, [setRun]);
 
   const restarteRun = useCallback(() => {
     if (!run || !quizData) return;
-    const gemischt = [...run.frageIds];
-    for (let i = gemischt.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [gemischt[i], gemischt[j]] = [gemischt[j], gemischt[i]];
-    }
-
-    let newAnswerShuffle: Record<string, ('A' | 'B' | 'C')[]> | undefined;
-    if (run.answerShuffle) {
-      newAnswerShuffle = {};
-      for (const id of gemischt) {
-        const f = quizData.fragen.find(q => q.id === id);
-        if (f) {
-          const { order } = computeShuffle(f);
-          newAnswerShuffle[id] = order;
-        }
-      }
-    }
-
-    persistRun({
-      ...run,
-      frageIds: gemischt,
-      antworten: {},
-      aktuellerIndex: 0,
-      startedAt: new Date().toISOString(),
-      selfAssessments: {},
-      completedAt: undefined,
-      answerShuffle: newAnswerShuffle,
-      gameMode: run.gameMode ?? gameMode,
-    });
+    const next = RunEngine.restartRun(run, quizData);
+    persistRun({ ...next, gameMode: next.gameMode ?? gameMode });
   }, [run, quizData, persistRun, gameMode]);
 
   const aktiveFragen = useMemo<Frage[]>(() => {
     if (!run || !quizData) return [];
-    return run.frageIds
-      .map(id => {
-        const f = quizData.fragen.find(q => q.id === id);
-        if (!f) return undefined;
-        const shuffle = run.answerShuffle?.[f.id];
-        if (shuffle) {
-          const keys: ('A' | 'B' | 'C')[] = ['A', 'B', 'C'];
-          const antworten = {
-            A: f.antworten[shuffle[0]],
-            B: f.antworten[shuffle[1]],
-            C: f.antworten[shuffle[2]],
-          };
-          const richtige_antwort = keys[shuffle.indexOf(f.richtige_antwort)];
-          return { ...f, antworten, richtige_antwort };
-        }
-        return f;
-      })
-      .filter((f): f is Frage => f !== undefined);
+    return selectActiveQuestions(run, quizData);
   }, [run, quizData]);
 
   const aktuelleFrage = aktiveFragen[run?.aktuellerIndex ?? 0] || null;
 
-  const statistiken = useMemo(() => ({
-    beantwortet: run ? Object.keys(run.antworten).length : 0,
-    korrekt: aktiveFragen.filter(f => run && run.antworten[f.id] === f.richtige_antwort).length,
-    falsch: aktiveFragen.filter(f => run && f.id in run.antworten && run.antworten[f.id] !== f.richtige_antwort).length,
-    gesamt: aktiveFragen.length,
-  }), [aktiveFragen, run]);
+  const statistiken = useMemo(() => {
+    if (!run) return { beantwortet: 0, korrekt: 0, falsch: 0, gesamt: 0 };
+    return selectStatistics(run, aktiveFragen);
+  }, [aktiveFragen, run]);
 
   return {
     run,

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -1,43 +1,41 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import type { AppSettings, GameMode } from '@/types/quiz';
-import { SettingsStorage, migrateLegacyStorage } from '@/utils/storage';
+import { usePersistentState } from '@/hooks/usePersistentState';
+import { createSettingsAdapter } from '@/utils/persistence/settingsAdapter';
+import type { PersistenceAdapter } from '@/utils/persistence';
+import { migrateLegacyStorage } from '@/utils/storage';
 
-export function useSettings() {
+const STORAGE_KEY_SETTINGS = 'fmq:settings:v1';
+const DEFAULT_SETTINGS: AppSettings = { gameMode: 'arcade' };
+const defaultAdapter = createSettingsAdapter();
+
+export function useSettings(adapter: PersistenceAdapter = defaultAdapter) {
   // Einmalig beim App-Start: Legacy-Storage migrieren
   useEffect(() => {
     migrateLegacyStorage();
   }, []);
 
-  const [settings, setSettings] = useState<AppSettings>(() => SettingsStorage.load());
+  const [settings, setSettings] = usePersistentState(STORAGE_KEY_SETTINGS, DEFAULT_SETTINGS, adapter);
 
   const setGameMode = useCallback((mode: GameMode) => {
     setSettings(prev => ({ ...prev, gameMode: mode }));
-  }, []);
+  }, [setSettings]);
 
   const setBackupReminderEnabled = useCallback((enabled: boolean) => {
     setSettings(prev => ({ ...prev, backupReminderEnabled: enabled }));
-  }, []);
+  }, [setSettings]);
 
   const setLastBackupPrompt = useCallback((date: string) => {
     setSettings(prev => ({ ...prev, lastBackupPrompt: date }));
-  }, []);
+  }, [setSettings]);
 
   const setShuffleAnswers = useCallback((enabled: boolean) => {
     setSettings(prev => ({ ...prev, shuffleAnswers: enabled }));
-  }, []);
+  }, [setSettings]);
 
   const importSettings = useCallback((data: AppSettings) => {
     setSettings(data);
-  }, []);
-
-  // Persistiere Settings bei Änderungen
-  useEffect(() => {
-    try {
-      SettingsStorage.save(settings);
-    } catch {
-      // Silently ignore storage errors to avoid blocking UI updates
-    }
-  }, [settings]);
+  }, [setSettings]);
 
   return {
     settings,

--- a/src/store/srs.ts
+++ b/src/store/srs.ts
@@ -1,8 +1,12 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { SRSMeta, SelfAssessmentGrade } from '@/types/quiz';
-import { SRSMetaSchema } from '@/utils/quizLoader';
-import { SRSStorage } from '@/utils/storage';
+import { usePersistentState } from '@/hooks/usePersistentState';
+import { createSRSAdapter } from '@/utils/persistence/srsAdapter';
+import type { PersistenceAdapter } from '@/utils/persistence';
 import { sm2, calculateNextReview, DEFAULT_SRS_STATE, SELF_ASSESSMENT_QUALITY } from '@/utils/srs';
+
+const STORAGE_KEY = 'fmq:meta:srs:v1';
+const defaultAdapter = createSRSAdapter();
 
 function bootstrapSRSMeta(): SRSMeta {
   return {
@@ -11,24 +15,12 @@ function bootstrapSRSMeta(): SRSMeta {
   };
 }
 
-export function useSRS() {
-  const [srsMap, setSrsMap] = useState<Record<string, SRSMeta>>(() => {
-    const loaded = SRSStorage.load();
-    const result: Record<string, SRSMeta> = {};
-    for (const [key, value] of Object.entries(loaded)) {
-      const parsed = SRSMetaSchema.safeParse(value);
-      if (parsed.success) {
-        result[key] = parsed.data;
-      } else {
-        console.warn('[SRS] Invalid entry for', key, parsed.error.format());
-      }
-    }
-    return result;
-  });
-
-  const persist = useCallback((next: Record<string, SRSMeta>) => {
-    setSrsMap(next);
-  }, []);
+export function useSRS(adapter: PersistenceAdapter = defaultAdapter) {
+  const [srsMap, setSrsMap] = usePersistentState<Record<string, SRSMeta>>(
+    STORAGE_KEY,
+    {},
+    adapter,
+  );
 
   const recordAnswer = useCallback((frageId: string, quality: number) => {
     setSrsMap(prev => {
@@ -40,7 +32,7 @@ export function useSRS() {
       };
       return { ...prev, [frageId]: nextMeta };
     });
-  }, []);
+  }, [setSrsMap]);
 
   const recordSelfAssessment = useCallback((frageId: string, grade: SelfAssessmentGrade) => {
     const quality = SELF_ASSESSMENT_QUALITY[grade] ?? 0;
@@ -74,16 +66,8 @@ export function useSRS() {
   }, [srsMap]);
 
   const reset = useCallback(() => {
-    persist({});
-  }, [persist]);
-
-  useEffect(() => {
-    try {
-      SRSStorage.save(srsMap);
-    } catch {
-      // Silently ignore storage errors
-    }
-  }, [srsMap]);
+    setSrsMap({});
+  }, [setSrsMap]);
 
   return {
     srsMap,

--- a/src/test/backup.test.ts
+++ b/src/test/backup.test.ts
@@ -1,26 +1,34 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useSettings } from '@/store/settings';
 import { AppBackupSchema } from '@/utils/quizLoader';
+import { memoryAdapter } from '@/utils/persistence/memoryAdapter';
+import { createSettingsAdapter } from '@/utils/persistence/settingsAdapter';
+
+const TEST_KEY = 'fmq:settings:v1';
 
 describe('Backup / Settings', () => {
+  beforeEach(() => {
+    memoryAdapter.clear(TEST_KEY);
+  });
+
   it('sollte backupReminderEnabled default false haben', () => {
-    const { result } = renderHook(() => useSettings());
+    const { result } = renderHook(() => useSettings(createSettingsAdapter(memoryAdapter)));
     expect(result.current.backupReminderEnabled).toBe(false);
     expect(result.current.lastBackupPrompt).toBeUndefined();
   });
 
   it('sollte backupReminderEnabled aktivieren', () => {
-    const { result } = renderHook(() => useSettings());
+    const { result } = renderHook(() => useSettings(createSettingsAdapter(memoryAdapter)));
     act(() => {
       result.current.setBackupReminderEnabled(true);
     });
     expect(result.current.backupReminderEnabled).toBe(true);
-    expect(localStorage.getItem('fmq:settings:v1')).toContain('backupReminderEnabled');
+    expect((memoryAdapter.load(TEST_KEY) as { backupReminderEnabled?: boolean }).backupReminderEnabled).toBe(true);
   });
 
   it('sollte lastBackupPrompt setzen', () => {
-    const { result } = renderHook(() => useSettings());
+    const { result } = renderHook(() => useSettings(createSettingsAdapter(memoryAdapter)));
     const now = new Date().toISOString();
     act(() => {
       result.current.setLastBackupPrompt(now);
@@ -29,8 +37,8 @@ describe('Backup / Settings', () => {
   });
 
   it('sollte korrupte Settings mit Defaults ersetzen', () => {
-    localStorage.setItem('fmq:settings:v1', JSON.stringify({ backupReminderEnabled: 'ja' }));
-    const { result } = renderHook(() => useSettings());
+    memoryAdapter.save(TEST_KEY, { backupReminderEnabled: 'ja' });
+    const { result } = renderHook(() => useSettings(createSettingsAdapter(memoryAdapter)));
     expect(result.current.backupReminderEnabled).toBe(false);
   });
 });

--- a/src/test/history.test.ts
+++ b/src/test/history.test.ts
@@ -1,15 +1,23 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useHistory } from '@/store/history';
+import { memoryAdapter } from '@/utils/persistence/memoryAdapter';
+import { createHistoryAdapter } from '@/utils/persistence/historyAdapter';
+
+const TEST_KEY = 'fmq:history:v1';
 
 describe('useHistory', () => {
+  beforeEach(() => {
+    memoryAdapter.clear(TEST_KEY);
+  });
+
   it('sollte mit leerem Verlauf starten', () => {
-    const { result } = renderHook(() => useHistory());
+    const { result } = renderHook(() => useHistory(createHistoryAdapter(memoryAdapter)));
     expect(result.current.entries).toEqual([]);
   });
 
   it('sollte einen Eintrag hinzufügen', () => {
-    const { result } = renderHook(() => useHistory());
+    const { result } = renderHook(() => useHistory(createHistoryAdapter(memoryAdapter)));
     act(() => {
       result.current.addEntry({
         topics: ['Biologie'],
@@ -25,7 +33,7 @@ describe('useHistory', () => {
   });
 
   it('sollte Einträge an den Anfang stellen', () => {
-    const { result } = renderHook(() => useHistory());
+    const { result } = renderHook(() => useHistory(createHistoryAdapter(memoryAdapter)));
     act(() => {
       result.current.addEntry({
         topics: ['Biologie'],
@@ -47,7 +55,7 @@ describe('useHistory', () => {
   });
 
   it('sollte maximal 500 Einträge halten', () => {
-    const { result } = renderHook(() => useHistory());
+    const { result } = renderHook(() => useHistory(createHistoryAdapter(memoryAdapter)));
     act(() => {
       for (let i = 0; i < 502; i++) {
         result.current.addEntry({
@@ -62,7 +70,7 @@ describe('useHistory', () => {
     expect(result.current.entries).toHaveLength(500);
   });
 
-  it('sollte Einträge aus localStorage laden', () => {
+  it('sollte Einträge aus Adapter laden', () => {
     const existing = [
       {
         id: 'test-1',
@@ -74,14 +82,14 @@ describe('useHistory', () => {
         mode: 'arcade',
       },
     ];
-    localStorage.setItem('fmq:history:v1', JSON.stringify(existing));
-    const { result } = renderHook(() => useHistory());
+    memoryAdapter.save(TEST_KEY, existing);
+    const { result } = renderHook(() => useHistory(createHistoryAdapter(memoryAdapter)));
     expect(result.current.entries).toHaveLength(1);
     expect(result.current.entries[0].id).toBe('test-1');
   });
 
   it('sollte den Verlauf löschen', () => {
-    const { result } = renderHook(() => useHistory());
+    const { result } = renderHook(() => useHistory(createHistoryAdapter(memoryAdapter)));
     act(() => {
       result.current.addEntry({
         topics: ['Biologie'],
@@ -98,7 +106,7 @@ describe('useHistory', () => {
   });
 
   it('sollte Einträge importieren', () => {
-    const { result } = renderHook(() => useHistory());
+    const { result } = renderHook(() => useHistory(createHistoryAdapter(memoryAdapter)));
     act(() => {
       result.current.importHistory([
         {
@@ -117,7 +125,7 @@ describe('useHistory', () => {
   });
 
   it('sollte jeder Eintrag eine eindeutige ID haben', () => {
-    const { result } = renderHook(() => useHistory());
+    const { result } = renderHook(() => useHistory(createHistoryAdapter(memoryAdapter)));
     act(() => {
       result.current.addEntry({
         topics: ['Biologie'],
@@ -149,8 +157,8 @@ describe('useHistory', () => {
         mode: 'arcade',
       },
     ];
-    localStorage.setItem('fmq:history:v1', JSON.stringify(legacy));
-    const { result } = renderHook(() => useHistory());
+    memoryAdapter.save(TEST_KEY, legacy);
+    const { result } = renderHook(() => useHistory(createHistoryAdapter(memoryAdapter)));
     expect(result.current.entries).toHaveLength(1);
     expect(result.current.entries[0].topics).toEqual(['Recht', 'Biologie']);
   });

--- a/src/test/metaProgress.test.ts
+++ b/src/test/metaProgress.test.ts
@@ -1,10 +1,18 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useMetaProgress } from '@/store/metaProgress';
+import { memoryAdapter } from '@/utils/persistence/memoryAdapter';
+import { createMetaAdapter } from '@/utils/persistence/metaAdapter';
 
 describe('useMetaProgress', () => {
+  beforeEach(() => {
+    memoryAdapter.clear('fmq:meta:arcade:v2');
+    memoryAdapter.clear('fmq:meta:hardcore:v2');
+    memoryAdapter.clear('fmq:meta:exam:v2');
+  });
+
   it('sollte initial leere Meta-Daten haben', () => {
-    const { result } = renderHook(() => useMetaProgress('arcade'));
+    const { result } = renderHook(() => useMetaProgress('arcade', createMetaAdapter(memoryAdapter)));
 
     expect(result.current.meta.stats.totalRuns).toBe(0);
     expect(result.current.meta.stats.totalQuestionsAnswered).toBe(0);
@@ -12,7 +20,7 @@ describe('useMetaProgress', () => {
   });
 
   it('sollte correctStreak bei richtiger Antwort erhöhen', () => {
-    const { result } = renderHook(() => useMetaProgress('arcade'));
+    const { result } = renderHook(() => useMetaProgress('arcade', createMetaAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordAnswer('q1', true);
@@ -25,7 +33,7 @@ describe('useMetaProgress', () => {
   });
 
   it('sollte correctStreak bei 3 richtigen Antworten zu Meister machen', () => {
-    const { result } = renderHook(() => useMetaProgress('arcade'));
+    const { result } = renderHook(() => useMetaProgress('arcade', createMetaAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordAnswer('q1', true);
@@ -37,7 +45,7 @@ describe('useMetaProgress', () => {
   });
 
   it('sollte correctStreak bei falscher Antwort zurücksetzen', () => {
-    const { result } = renderHook(() => useMetaProgress('arcade'));
+    const { result } = renderHook(() => useMetaProgress('arcade', createMetaAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordAnswer('q1', true);
@@ -49,7 +57,7 @@ describe('useMetaProgress', () => {
   });
 
   it('sollte beste Serie (bestStreak) tracken', () => {
-    const { result } = renderHook(() => useMetaProgress('arcade'));
+    const { result } = renderHook(() => useMetaProgress('arcade', createMetaAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordAnswer('q1', true);
@@ -69,7 +77,7 @@ describe('useMetaProgress', () => {
   });
 
   it('sollte totalRuns erhöhen', () => {
-    const { result } = renderHook(() => useMetaProgress('arcade'));
+    const { result } = renderHook(() => useMetaProgress('arcade', createMetaAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordRunStart();
@@ -79,7 +87,7 @@ describe('useMetaProgress', () => {
   });
 
   it('sollte alles zurücksetzen', () => {
-    const { result } = renderHook(() => useMetaProgress('arcade'));
+    const { result } = renderHook(() => useMetaProgress('arcade', createMetaAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordAnswer('q1', true);
@@ -99,7 +107,7 @@ describe('useMetaProgress', () => {
   });
 
   it('sollte getFrageMeta für bekannte Fragen zurückgeben', () => {
-    const { result } = renderHook(() => useMetaProgress('arcade'));
+    const { result } = renderHook(() => useMetaProgress('arcade', createMetaAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordAnswer('q1', true);
@@ -114,8 +122,8 @@ describe('useMetaProgress', () => {
   });
 
   it('sollte Meta-Daten pro Modus getrennt speichern', () => {
-    const { result: arcade } = renderHook(() => useMetaProgress('arcade'));
-    const { result: hardcore } = renderHook(() => useMetaProgress('hardcore'));
+    const { result: arcade } = renderHook(() => useMetaProgress('arcade', createMetaAdapter(memoryAdapter)));
+    const { result: hardcore } = renderHook(() => useMetaProgress('hardcore', createMetaAdapter(memoryAdapter)));
 
     act(() => {
       arcade.current.recordAnswer('q1', true);
@@ -127,7 +135,7 @@ describe('useMetaProgress', () => {
   });
 
   it('sollte Topic-Result als passed speichern', () => {
-    const { result } = renderHook(() => useMetaProgress('hardcore'));
+    const { result } = renderHook(() => useMetaProgress('hardcore', createMetaAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordTopicResult('Biologie', true);
@@ -141,7 +149,7 @@ describe('useMetaProgress', () => {
   });
 
   it('sollte consecutivePasses bei passed erhöhen', () => {
-    const { result } = renderHook(() => useMetaProgress('hardcore'));
+    const { result } = renderHook(() => useMetaProgress('hardcore', createMetaAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordTopicResult('Biologie', true);
@@ -153,7 +161,7 @@ describe('useMetaProgress', () => {
   });
 
   it('sollte mastered nach 3 konsekutiven Passe setzen', () => {
-    const { result } = renderHook(() => useMetaProgress('hardcore'));
+    const { result } = renderHook(() => useMetaProgress('hardcore', createMetaAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordTopicResult('Biologie', true);
@@ -167,7 +175,7 @@ describe('useMetaProgress', () => {
   });
 
   it('sollte consecutivePasses bei failed zurücksetzen', () => {
-    const { result } = renderHook(() => useMetaProgress('hardcore'));
+    const { result } = renderHook(() => useMetaProgress('hardcore', createMetaAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordTopicResult('Biologie', true);
@@ -181,7 +189,7 @@ describe('useMetaProgress', () => {
   });
 
   it('sollte Topic-Results beim Reset löschen', () => {
-    const { result } = renderHook(() => useMetaProgress('hardcore'));
+    const { result } = renderHook(() => useMetaProgress('hardcore', createMetaAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordTopicResult('Biologie', true);

--- a/src/test/notes.test.ts
+++ b/src/test/notes.test.ts
@@ -1,25 +1,32 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useNotes } from '@/store/notes';
+import { memoryAdapter } from '@/utils/persistence/memoryAdapter';
+
+const TEST_KEY = 'fmq:notes:v1';
 
 describe('useNotes', () => {
+  beforeEach(() => {
+    memoryAdapter.clear(TEST_KEY);
+  });
+
   it('sollte mit leeren Notizen starten', () => {
-    const { result } = renderHook(() => useNotes());
+    const { result } = renderHook(() => useNotes(memoryAdapter));
     expect(result.current.notes).toEqual({});
     expect(result.current.getNote('f1')).toBe('');
   });
 
   it('sollte eine Notiz speichern', () => {
-    const { result } = renderHook(() => useNotes());
+    const { result } = renderHook(() => useNotes(memoryAdapter));
     act(() => {
       result.current.setNote('f1', 'Eselsbrücke: A ist immer richtig');
     });
     expect(result.current.getNote('f1')).toBe('Eselsbrücke: A ist immer richtig');
-    expect(localStorage.getItem('fmq:notes:v1')).toContain('Eselsbrücke');
+    expect(memoryAdapter.load(TEST_KEY)).toEqual({ f1: 'Eselsbrücke: A ist immer richtig' });
   });
 
   it('sollte eine Notiz aktualisieren', () => {
-    const { result } = renderHook(() => useNotes());
+    const { result } = renderHook(() => useNotes(memoryAdapter));
     act(() => {
       result.current.setNote('f1', 'Erste Version');
     });
@@ -30,7 +37,7 @@ describe('useNotes', () => {
   });
 
   it('sollte eine Notiz löschen wenn leer', () => {
-    const { result } = renderHook(() => useNotes());
+    const { result } = renderHook(() => useNotes(memoryAdapter));
     act(() => {
       result.current.setNote('f1', 'Wird gelöscht');
     });
@@ -43,7 +50,7 @@ describe('useNotes', () => {
   });
 
   it('sollte mehrere Notizen unabhängig verwalten', () => {
-    const { result } = renderHook(() => useNotes());
+    const { result } = renderHook(() => useNotes(memoryAdapter));
     act(() => {
       result.current.setNote('f1', 'Notiz 1');
       result.current.setNote('f2', 'Notiz 2');
@@ -52,14 +59,14 @@ describe('useNotes', () => {
     expect(result.current.getNote('f2')).toBe('Notiz 2');
   });
 
-  it('sollte Notizen aus localStorage laden', () => {
-    localStorage.setItem('fmq:notes:v1', JSON.stringify({ f1: 'Persistiert' }));
-    const { result } = renderHook(() => useNotes());
+  it('sollte Notizen aus Adapter laden', () => {
+    memoryAdapter.save(TEST_KEY, { f1: 'Persistiert' });
+    const { result } = renderHook(() => useNotes(memoryAdapter));
     expect(result.current.getNote('f1')).toBe('Persistiert');
   });
 
   it('sollte Notizen zurücksetzen', () => {
-    const { result } = renderHook(() => useNotes());
+    const { result } = renderHook(() => useNotes(memoryAdapter));
     act(() => {
       result.current.setNote('f1', 'Weg');
     });
@@ -71,7 +78,7 @@ describe('useNotes', () => {
   });
 
   it('sollte Notizen importieren', () => {
-    const { result } = renderHook(() => useNotes());
+    const { result } = renderHook(() => useNotes(memoryAdapter));
     act(() => {
       result.current.importNotes({ f3: 'Importiert' });
     });
@@ -79,7 +86,7 @@ describe('useNotes', () => {
   });
 
   it('sollte Whitespace trimmen', () => {
-    const { result } = renderHook(() => useNotes());
+    const { result } = renderHook(() => useNotes(memoryAdapter));
     act(() => {
       result.current.setNote('f1', '  Mit Leerzeichen  ');
     });

--- a/src/test/persistence.test.ts
+++ b/src/test/persistence.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { memoryAdapter } from '@/utils/persistence/memoryAdapter';
+import { localStorageAdapter } from '@/utils/persistence/localStorageAdapter';
+
+describe('memoryAdapter', () => {
+  beforeEach(() => {
+    memoryAdapter.clear('test-key');
+  });
+
+  it('returns default when key absent', () => {
+    const value = memoryAdapter.load('test-key');
+    expect(value).toBeNull();
+  });
+
+  it('round-trips data', () => {
+    memoryAdapter.save('test-key', { foo: 'bar' });
+    const value = memoryAdapter.load('test-key');
+    expect(value).toEqual({ foo: 'bar' });
+  });
+
+  it('clears data', () => {
+    memoryAdapter.save('test-key', 42);
+    memoryAdapter.clear('test-key');
+    const value = memoryAdapter.load('test-key');
+    expect(value).toBeNull();
+  });
+});
+
+describe('localStorageAdapter', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('saves JSON to localStorage', () => {
+    localStorageAdapter.save('ls-key', { num: 1 });
+    expect(localStorage.getItem('ls-key')).toBe('{"num":1}');
+  });
+
+  it('loads parsed JSON from localStorage', () => {
+    localStorage.setItem('ls-key', '{"num":1}');
+    const value = localStorageAdapter.load('ls-key');
+    expect(value).toEqual({ num: 1 });
+  });
+
+  it('returns null when key absent', () => {
+    const value = localStorageAdapter.load('missing');
+    expect(value).toBeNull();
+  });
+
+  it('clears key from localStorage', () => {
+    localStorage.setItem('ls-key', 'x');
+    localStorageAdapter.clear('ls-key');
+    expect(localStorage.getItem('ls-key')).toBeNull();
+  });
+});

--- a/src/test/quizRun.test.ts
+++ b/src/test/quizRun.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useQuizRun } from '@/store/quizRun';
 import type { QuizData } from '@/types/quiz';
+import { memoryAdapter } from '@/utils/persistence/memoryAdapter';
 
 const mockQuizData: QuizData = {
   meta: {
@@ -20,8 +21,14 @@ const mockQuizData: QuizData = {
 };
 
 describe('useQuizRun', () => {
+  beforeEach(() => {
+    memoryAdapter.clear('fmq:run:arcade:v2');
+    memoryAdapter.clear('fmq:run:hardcore:v2');
+    memoryAdapter.clear('fmq:run:exam:v2');
+  });
+
   it('sollte initial inaktiv sein', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     expect(result.current.isActive).toBe(false);
     expect(result.current.aktiveFragen).toEqual([]);
@@ -29,7 +36,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte einen neuen Run starten', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie']);
@@ -42,7 +49,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte Fragen mischen (Shuffle)', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie', 'Recht']);
@@ -60,7 +67,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte eine Antwort speichern', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie']);
@@ -77,7 +84,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte keine Antwort überschreiben', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie']);
@@ -94,7 +101,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte zur nächsten Frage navigieren', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie', 'Recht']);
@@ -110,7 +117,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte nicht über die letzte Frage hinaus navigieren', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie']);
@@ -132,7 +139,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte zur vorherigen Frage navigieren', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie', 'Recht']);
@@ -153,7 +160,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte nicht vor die erste Frage navigieren', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie']);
@@ -167,7 +174,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte zu einer bestimmten Frage springen', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie', 'Recht']);
@@ -181,7 +188,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte einen Run unterbrechen', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie']);
@@ -197,7 +204,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte Statistiken korrekt berechnen', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie']);
@@ -217,7 +224,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte Topics erweitern', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie']);
@@ -236,7 +243,7 @@ describe('useQuizRun', () => {
 
   it('sollte startedAt beim Erweitern zurücksetzen', () => {
     vi.useFakeTimers();
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie']);
@@ -259,8 +266,8 @@ describe('useQuizRun', () => {
   });
 
   it('sollte Runs pro Modus getrennt speichern', () => {
-    const { result: arcade } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
-    const { result: hardcore } = renderHook(() => useQuizRun(mockQuizData, 'hardcore'));
+    const { result: arcade } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
+    const { result: hardcore } = renderHook(() => useQuizRun(mockQuizData, 'hardcore', memoryAdapter));
 
     act(() => {
       arcade.current.starteRun(['Biologie']);
@@ -271,7 +278,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte fehlende Fragen aus dem Run bereinigen (Issue #17)', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie']);
@@ -285,7 +292,7 @@ describe('useQuizRun', () => {
       fragen: mockQuizData.fragen.filter(f => f.id !== '1'),
     };
 
-    const { result: result2 } = renderHook(() => useQuizRun(reducedQuizData, 'arcade'));
+    const { result: result2 } = renderHook(() => useQuizRun(reducedQuizData, 'arcade', memoryAdapter));
 
     // Nach Bereinigung sollten nur noch 2 Fragen aktiv sein
     expect(result2.current.aktiveFragen.length).toBe(2);
@@ -293,7 +300,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte aktuellen Index anpassen wenn Fragen entfernt werden (Issue #17)', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie']);
@@ -313,7 +320,7 @@ describe('useQuizRun', () => {
       fragen: mockQuizData.fragen.filter(f => f.id === '1'),
     };
 
-    const { result: result2 } = renderHook(() => useQuizRun(reducedQuizData, 'arcade'));
+    const { result: result2 } = renderHook(() => useQuizRun(reducedQuizData, 'arcade', memoryAdapter));
 
     // Index sollte auf 0 zurückgesetzt werden (letzter verbleibender Index)
     expect(result2.current.aktuellerIndex).toBe(0);
@@ -321,7 +328,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte einen Topic chirurgisch aus dem Run entfernen', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie', 'Recht']);
@@ -342,7 +349,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte Antworten entfernter Fragen aus dem Run löschen', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie', 'Recht']);
@@ -364,7 +371,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte den Index anpassen wenn der aktuelle Topic entfernt wird', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie', 'Recht']);
@@ -397,7 +404,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte den Run beenden wenn der letzte Topic entfernt wird', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie']);
@@ -414,7 +421,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte nichts tun wenn ein unbekannter Topic entfernt werden soll', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie']);
@@ -431,7 +438,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte answerShuffle für jede Frage generieren wenn Shuffle aktiviert', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie'], undefined, undefined, undefined, undefined, true);
@@ -446,7 +453,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte aktiveFragen in gemischter Reihenfolge anzeigen wenn Shuffle aktiv', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie'], undefined, undefined, undefined, undefined, true);
@@ -462,7 +469,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte bei restarteRun eine neue answerShuffle generieren', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie'], undefined, undefined, undefined, undefined, true);
@@ -480,7 +487,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte Shuffle-Einträge beim Entfernen eines Topics löschen', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie', 'Recht'], undefined, undefined, undefined, undefined, true);
@@ -504,7 +511,7 @@ describe('useQuizRun', () => {
   });
 
   it('sollte Antworten nach Shuffle korrekt bewerten', () => {
-    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade'));
+    const { result } = renderHook(() => useQuizRun(mockQuizData, 'arcade', memoryAdapter));
 
     act(() => {
       result.current.starteRun(['Biologie'], undefined, undefined, undefined, undefined, true);

--- a/src/test/runEngine.test.ts
+++ b/src/test/runEngine.test.ts
@@ -1,0 +1,470 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { QuizData, QuizRun } from '@/types/quiz';
+import * as RunEngine from '@/engine/runEngine';
+import { selectActiveQuestions, selectStatistics } from '@/engine/runSelectors';
+
+const mockQuizData: QuizData = {
+  meta: {
+    titel: 'Test',
+    anzahl_fragen: 6,
+    topics: { Biologie: 3, Recht: 3 },
+  },
+  fragen: [
+    { id: '1', topic: 'Biologie', frage: 'F1', antworten: { A: 'a', B: 'b', C: 'c' }, richtige_antwort: 'A' },
+    { id: '2', topic: 'Biologie', frage: 'F2', antworten: { A: 'a', B: 'b', C: 'c' }, richtige_antwort: 'B' },
+    { id: '3', topic: 'Biologie', frage: 'F3', antworten: { A: 'a', B: 'b', C: 'c' }, richtige_antwort: 'C' },
+    { id: '4', topic: 'Recht', frage: 'F4', antworten: { A: 'a', B: 'b', C: 'c' }, richtige_antwort: 'A' },
+    { id: '5', topic: 'Recht', frage: 'F5', antworten: { A: 'a', B: 'b', C: 'c' }, richtige_antwort: 'B' },
+    { id: '6', topic: 'Recht', frage: 'F6', antworten: { A: 'a', B: 'b', C: 'c' }, richtige_antwort: 'C' },
+  ],
+};
+
+describe('RunEngine', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('createRun', () => {
+    it('creates an active run with shuffled question IDs for given topics', () => {
+      const run = RunEngine.createRun(mockQuizData, ['Biologie']);
+      expect(run.isActive).toBe(true);
+      expect(run.frageIds).toHaveLength(3);
+      expect(run.topics).toEqual(['Biologie']);
+      expect(run.aktuellerIndex).toBe(0);
+      expect(run.antworten).toEqual({});
+      expect(run.startedAt).toBe('2026-01-01T00:00:00.000Z');
+    });
+
+    it('respects limit option', () => {
+      const run = RunEngine.createRun(mockQuizData, ['Biologie', 'Recht'], { limit: 2 });
+      expect(run.frageIds).toHaveLength(2);
+    });
+
+    it('sets durationSeconds and sessionType', () => {
+      const run = RunEngine.createRun(mockQuizData, ['Biologie'], { durationSeconds: 3600, sessionType: 'flashcard' });
+      expect(run.durationSeconds).toBe(3600);
+      expect(run.sessionType).toBe('flashcard');
+    });
+
+    it('defaults sessionType to quiz', () => {
+      const run = RunEngine.createRun(mockQuizData, ['Biologie']);
+      expect(run.sessionType).toBe('quiz');
+    });
+
+    it('generates answerShuffle when enableShuffle is true', () => {
+      const run = RunEngine.createRun(mockQuizData, ['Biologie'], { enableShuffle: true });
+      expect(run.answerShuffle).toBeDefined();
+      for (const id of run.frageIds) {
+        expect(run.answerShuffle![id]).toHaveLength(3);
+      }
+    });
+
+    it('does not generate answerShuffle when enableShuffle is false', () => {
+      const run = RunEngine.createRun(mockQuizData, ['Biologie'], { enableShuffle: false });
+      expect(run.answerShuffle).toBeUndefined();
+    });
+  });
+
+  describe('extendRun', () => {
+    it('appends new topic questions and preserves existing answers', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2', '3'],
+        antworten: { '1': 'A' },
+        topics: ['Biologie'],
+        aktuellerIndex: 1,
+        isActive: true,
+        startedAt: '2025-01-01T00:00:00.000Z',
+      };
+      const extended = RunEngine.extendRun(run, mockQuizData, ['Recht']);
+      expect(extended).not.toBeNull();
+      expect(extended!.topics).toContain('Biologie');
+      expect(extended!.topics).toContain('Recht');
+      expect(extended!.frageIds).toHaveLength(6);
+      expect(extended!.antworten).toEqual({ '1': 'A' });
+      expect(extended!.startedAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(extended!.completedAt).toBeUndefined();
+    });
+
+    it('returns null when there are no new questions', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2', '3'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      expect(RunEngine.extendRun(run, mockQuizData, ['Biologie'])).toBeNull();
+    });
+
+    it('returns null for timed runs', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2', '3'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+        durationSeconds: 3600,
+      };
+      expect(RunEngine.extendRun(run, mockQuizData, ['Recht'])).toBeNull();
+    });
+
+    it('generates answerShuffle for new questions when enabled', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2', '3'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+        answerShuffle: { '1': ['B', 'A', 'C'], '2': ['A', 'C', 'B'], '3': ['C', 'A', 'B'] },
+      };
+      const extended = RunEngine.extendRun(run, mockQuizData, ['Recht'], true);
+      expect(extended).not.toBeNull();
+      expect(extended!.answerShuffle!['1']).toEqual(['B', 'A', 'C']);
+      for (const id of extended!.frageIds) {
+        expect(extended!.answerShuffle![id]).toHaveLength(3);
+      }
+    });
+  });
+
+  describe('answerQuestion', () => {
+    it('stores an answer immutably', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      const next = RunEngine.answerQuestion(run, '1', 'A');
+      expect(next.antworten['1']).toBe('A');
+      expect(run.antworten['1']).toBeUndefined();
+    });
+
+    it('ignores second answer for same question', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2'],
+        antworten: { '1': 'A' },
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      const next = RunEngine.answerQuestion(run, '1', 'B');
+      expect(next.antworten['1']).toBe('A');
+      expect(next).toBe(run);
+    });
+  });
+
+  describe('selfAssess', () => {
+    it('stores self-assessment grade', () => {
+      const run: QuizRun = {
+        frageIds: ['1'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      const next = RunEngine.selfAssess(run, '1', 'good');
+      expect(next.selfAssessments).toEqual({ '1': 'good' });
+    });
+  });
+
+  describe('navigation', () => {
+    const baseRun: QuizRun = {
+      frageIds: ['1', '2', '3'],
+      antworten: {},
+      topics: ['Biologie'],
+      aktuellerIndex: 1,
+      isActive: true,
+    };
+
+    it('nextQuestion increments index', () => {
+      const next = RunEngine.nextQuestion(baseRun);
+      expect(next.aktuellerIndex).toBe(2);
+    });
+
+    it('nextQuestion clamps at end', () => {
+      const run = { ...baseRun, aktuellerIndex: 2 };
+      expect(RunEngine.nextQuestion(run)).toBe(run);
+    });
+
+    it('prevQuestion decrements index', () => {
+      const next = RunEngine.prevQuestion(baseRun);
+      expect(next.aktuellerIndex).toBe(0);
+    });
+
+    it('prevQuestion clamps at start', () => {
+      const run = { ...baseRun, aktuellerIndex: 0 };
+      expect(RunEngine.prevQuestion(run)).toBe(run);
+    });
+
+    it('jumpToQuestion sets index', () => {
+      const next = RunEngine.jumpToQuestion(baseRun, 2);
+      expect(next.aktuellerIndex).toBe(2);
+    });
+
+    it('jumpToQuestion clamps out of bounds', () => {
+      expect(RunEngine.jumpToQuestion(baseRun, -1)).toBe(baseRun);
+      expect(RunEngine.jumpToQuestion(baseRun, 3)).toBe(baseRun);
+    });
+  });
+
+  describe('removeTopicFromRun', () => {
+    it('removes topic questions and updates index', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '4', '2', '5', '3', '6'],
+        antworten: { '1': 'A', '4': 'B' },
+        topics: ['Biologie', 'Recht'],
+        aktuellerIndex: 3,
+        isActive: true,
+      };
+      const next = RunEngine.removeTopicFromRun(run, mockQuizData, 'Biologie');
+      expect(next).not.toBeNull();
+      expect(next!.frageIds).toEqual(['4', '5', '6']);
+      expect(next!.topics).toEqual(['Recht']);
+      expect(next!.antworten).toEqual({ '4': 'B' });
+      expect(next!.aktuellerIndex).toBeGreaterThanOrEqual(0);
+      expect(next!.aktuellerIndex).toBeLessThan(next!.frageIds.length);
+    });
+
+    it('returns null when run becomes empty', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2', '3'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      expect(RunEngine.removeTopicFromRun(run, mockQuizData, 'Biologie')).toBeNull();
+    });
+
+    it('returns same run when topic is unknown', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2', '3'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      expect(RunEngine.removeTopicFromRun(run, mockQuizData, 'Unbekannt')).toBe(run);
+    });
+
+    it('clears answerShuffle entries for removed questions', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2', '4'],
+        antworten: {},
+        topics: ['Biologie', 'Recht'],
+        aktuellerIndex: 0,
+        isActive: true,
+        answerShuffle: { '1': ['A', 'B', 'C'], '2': ['B', 'A', 'C'], '4': ['C', 'A', 'B'] },
+      };
+      const next = RunEngine.removeTopicFromRun(run, mockQuizData, 'Biologie');
+      expect(next).not.toBeNull();
+      expect(next!.answerShuffle).toEqual({ '4': ['C', 'A', 'B'] });
+    });
+
+    it('removes answerShuffle entirely when all entries removed', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2', '3'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+        answerShuffle: { '1': ['A', 'B', 'C'] },
+      };
+      const next = RunEngine.removeTopicFromRun(run, mockQuizData, 'Biologie');
+      expect(next).toBeNull();
+    });
+  });
+
+  describe('restartRun', () => {
+    it('reshuffles question IDs and clears answers', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2', '3'],
+        antworten: { '1': 'A' },
+        topics: ['Biologie'],
+        aktuellerIndex: 2,
+        isActive: true,
+        selfAssessments: { '1': 'good' },
+        completedAt: '2025-01-01T00:00:00.000Z',
+        startedAt: '2025-01-01T00:00:00.000Z',
+      };
+      const next = RunEngine.restartRun(run, mockQuizData);
+      expect(next.frageIds).toHaveLength(3);
+      expect(next.antworten).toEqual({});
+      expect(next.selfAssessments).toEqual({});
+      expect(next.aktuellerIndex).toBe(0);
+      expect(next.completedAt).toBeUndefined();
+      expect(next.startedAt).toBe('2026-01-01T00:00:00.000Z');
+    });
+
+    it('regenerates answerShuffle when present', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+        answerShuffle: { '1': ['A', 'B', 'C'], '2': ['B', 'A', 'C'] },
+      };
+      const next = RunEngine.restartRun(run, mockQuizData);
+      expect(next.answerShuffle).toBeDefined();
+      expect(Object.keys(next.answerShuffle!)).toHaveLength(2);
+    });
+  });
+
+  describe('detectInconsistency', () => {
+    it('returns missing IDs', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '99'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      expect(RunEngine.detectInconsistency(run, mockQuizData)).toEqual(['99']);
+    });
+
+    it('returns empty array when consistent', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2', '3'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      expect(RunEngine.detectInconsistency(run, mockQuizData)).toEqual([]);
+    });
+  });
+
+  describe('purgeMissingQuestions', () => {
+    it('returns same run when no missing questions', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2'],
+        antworten: { '1': 'A' },
+        topics: ['Biologie'],
+        aktuellerIndex: 1,
+        isActive: true,
+      };
+      expect(RunEngine.purgeMissingQuestions(run, mockQuizData)).toBe(run);
+    });
+
+    it('removes missing questions and adjusts index', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '99', '2'],
+        antworten: { '1': 'A', '99': 'B' },
+        topics: ['Biologie'],
+        aktuellerIndex: 2,
+        isActive: true,
+      };
+      const next = RunEngine.purgeMissingQuestions(run, mockQuizData);
+      expect(next).not.toBeNull();
+      expect(next!.frageIds).toEqual(['1', '2']);
+      expect(next!.antworten).toEqual({ '1': 'A' });
+      expect(next!.aktuellerIndex).toBe(1);
+    });
+
+    it('returns null when all questions are missing', () => {
+      const run: QuizRun = {
+        frageIds: ['99', '100'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      expect(RunEngine.purgeMissingQuestions(run, mockQuizData)).toBeNull();
+    });
+  });
+
+  describe('interruptRun / completeRun', () => {
+    it('interruptRun sets isActive false', () => {
+      const run: QuizRun = {
+        frageIds: ['1'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      expect(RunEngine.interruptRun(run).isActive).toBe(false);
+    });
+
+    it('completeRun sets completedAt', () => {
+      const run: QuizRun = {
+        frageIds: ['1'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      const next = RunEngine.completeRun(run);
+      expect(next.completedAt).toBe('2026-01-01T00:00:00.000Z');
+    });
+  });
+});
+
+describe('runSelectors', () => {
+  describe('selectActiveQuestions', () => {
+    it('maps frageIds to Frage objects', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '4'],
+        antworten: {},
+        topics: ['Biologie', 'Recht'],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      const active = selectActiveQuestions(run, mockQuizData);
+      expect(active).toHaveLength(2);
+      expect(active[0].id).toBe('1');
+      expect(active[1].id).toBe('4');
+    });
+
+    it('applies answerShuffle to answers and correct key', () => {
+      const run: QuizRun = {
+        frageIds: ['1'],
+        antworten: {},
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+        answerShuffle: { '1': ['B', 'C', 'A'] }, // original A->keys[2], B->keys[0], C->keys[1]
+      };
+      const active = selectActiveQuestions(run, mockQuizData);
+      expect(active).toHaveLength(1);
+      expect(active[0].antworten).toEqual({ A: 'b', B: 'c', C: 'a' });
+      expect(active[0].richtige_antwort).toBe('C'); // original A is now at index 2 -> key C
+    });
+  });
+
+  describe('selectStatistics', () => {
+    it('calculates stats correctly', () => {
+      const run: QuizRun = {
+        frageIds: ['1', '2', '3'],
+        antworten: { '1': 'A', '2': 'X' },
+        topics: ['Biologie'],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      const active = selectActiveQuestions(run, mockQuizData);
+      const stats = selectStatistics(run, active);
+      expect(stats.beantwortet).toBe(2);
+      expect(stats.korrekt).toBe(1); // 1 is correct
+      expect(stats.falsch).toBe(1); // 2 is wrong
+      expect(stats.gesamt).toBe(3);
+    });
+
+    it('returns zeros for empty run', () => {
+      const run: QuizRun = {
+        frageIds: [],
+        antworten: {},
+        topics: [],
+        aktuellerIndex: 0,
+        isActive: true,
+      };
+      const stats = selectStatistics(run, []);
+      expect(stats).toEqual({ beantwortet: 0, korrekt: 0, falsch: 0, gesamt: 0 });
+    });
+  });
+});

--- a/src/test/settings.test.ts
+++ b/src/test/settings.test.ts
@@ -1,17 +1,23 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useSettings } from '@/store/settings';
+import { memoryAdapter } from '@/utils/persistence/memoryAdapter';
+import { createSettingsAdapter } from '@/utils/persistence/settingsAdapter';
+
+const TEST_KEY = 'fmq:settings:v1';
 
 describe('useSettings', () => {
-  it('sollte initial Arcade als Default haben', () => {
-    const { result } = renderHook(() => useSettings());
+  beforeEach(() => {
+    memoryAdapter.clear(TEST_KEY);
+  });
 
+  it('sollte initial Arcade als Default haben', () => {
+    const { result } = renderHook(() => useSettings(createSettingsAdapter(memoryAdapter)));
     expect(result.current.gameMode).toBe('arcade');
   });
 
   it('sollte den Spielmodus wechseln', () => {
-    const { result } = renderHook(() => useSettings());
-
+    const { result } = renderHook(() => useSettings(createSettingsAdapter(memoryAdapter)));
     expect(result.current.gameMode).toBe('arcade');
 
     act(() => {
@@ -22,30 +28,30 @@ describe('useSettings', () => {
     expect(result.current.settings.gameMode).toBe('hardcore');
   });
 
-  it('sollte Settings in localStorage persistieren', () => {
-    const { result } = renderHook(() => useSettings());
+  it('sollte Settings in Adapter persistieren', () => {
+    const { result } = renderHook(() => useSettings(createSettingsAdapter(memoryAdapter)));
 
     act(() => {
       result.current.setGameMode('hardcore');
     });
 
-    const stored = localStorage.getItem('fmq:settings:v1');
+    const stored = memoryAdapter.load(TEST_KEY);
     expect(stored).toBeTruthy();
-    expect(JSON.parse(stored!).gameMode).toBe('hardcore');
+    expect((stored as { gameMode: string }).gameMode).toBe('hardcore');
   });
 
-  it('sollte Settings aus localStorage laden', () => {
-    localStorage.setItem('fmq:settings:v1', JSON.stringify({ gameMode: 'hardcore' }));
+  it('sollte Settings aus Adapter laden', () => {
+    memoryAdapter.save(TEST_KEY, { gameMode: 'hardcore' });
 
-    const { result } = renderHook(() => useSettings());
+    const { result } = renderHook(() => useSettings(createSettingsAdapter(memoryAdapter)));
 
     expect(result.current.gameMode).toBe('hardcore');
   });
 
-  it('sollte bei korruptem localStorage auf Defaults zurückfallen', () => {
-    localStorage.setItem('fmq:settings:v1', JSON.stringify({ gameMode: 'invalid_mode' }));
+  it('sollte bei korruptem Adapter-Daten auf Defaults zurückfallen', () => {
+    memoryAdapter.save(TEST_KEY, { gameMode: 'invalid_mode' });
 
-    const { result } = renderHook(() => useSettings());
+    const { result } = renderHook(() => useSettings(createSettingsAdapter(memoryAdapter)));
 
     expect(result.current.gameMode).toBe('arcade');
   });

--- a/src/test/srsStore.test.ts
+++ b/src/test/srsStore.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useSRS } from '@/store/srs';
+import { memoryAdapter } from '@/utils/persistence/memoryAdapter';
+import { createSRSAdapter } from '@/utils/persistence/srsAdapter';
+
+const TEST_KEY = 'fmq:meta:srs:v1';
 
 describe('useSRS', () => {
   beforeEach(() => {
-    localStorage.clear();
+    memoryAdapter.clear(TEST_KEY);
   });
 
   it('sollte initial leere SRS-Daten haben', () => {
-    const { result } = renderHook(() => useSRS());
+    const { result } = renderHook(() => useSRS(createSRSAdapter(memoryAdapter)));
 
     expect(result.current.dueCount).toBe(0);
     expect(result.current.dueFrageIds).toEqual([]);
@@ -16,7 +20,7 @@ describe('useSRS', () => {
   });
 
   it('sollte eine Antwort mit quality 4 aufnehmen', () => {
-    const { result } = renderHook(() => useSRS());
+    const { result } = renderHook(() => useSRS(createSRSAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordAnswer('q1', 4);
@@ -30,7 +34,7 @@ describe('useSRS', () => {
   });
 
   it('sollte eine Selbstbewertung (again) als quality 0 aufnehmen', () => {
-    const { result } = renderHook(() => useSRS());
+    const { result } = renderHook(() => useSRS(createSRSAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordSelfAssessment('q1', 'again');
@@ -43,7 +47,7 @@ describe('useSRS', () => {
   });
 
   it('sollte nach 3 erfolgreichen Wiederholungen repetitions >= 3 haben', () => {
-    const { result } = renderHook(() => useSRS());
+    const { result } = renderHook(() => useSRS(createSRSAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordAnswer('q1', 4); // interval 1
@@ -60,9 +64,8 @@ describe('useSRS', () => {
   });
 
   it('sollte dueCount für fällige Wiederholungen erhöhen', () => {
-    const { result } = renderHook(() => useSRS());
+    const { result } = renderHook(() => useSRS(createSRSAdapter(memoryAdapter)));
 
-    // Manuell eine überfällige Frage einfügen (nextReview gestern)
     act(() => {
       result.current.recordAnswer('q1', 4);
     });
@@ -70,17 +73,16 @@ describe('useSRS', () => {
     expect(meta).toBeDefined();
 
     // Überschreibe nextReview auf gestern, um Überfälligkeit zu simulieren
-    localStorage.setItem('fmq:meta:srs:v1', JSON.stringify({
+    memoryAdapter.save(TEST_KEY, {
       q1: { ...meta!, nextReview: new Date(Date.now() - 86400000).toISOString() },
-    }));
+    });
 
-    // Neu rendern um aus localStorage zu laden
-    const { result: result2 } = renderHook(() => useSRS());
+    const { result: result2 } = renderHook(() => useSRS(createSRSAdapter(memoryAdapter)));
     expect(result2.current.dueCount).toBe(1);
   });
 
   it('sollte alles zurücksetzen', () => {
-    const { result } = renderHook(() => useSRS());
+    const { result } = renderHook(() => useSRS(createSRSAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordAnswer('q1', 4);
@@ -97,27 +99,25 @@ describe('useSRS', () => {
     expect(result.current.srsMap).toEqual({});
   });
 
-  it('sollte SRS-Daten in localStorage persistieren', () => {
-    const { result } = renderHook(() => useSRS());
+  it('sollte SRS-Daten in Adapter persistieren', () => {
+    const { result } = renderHook(() => useSRS(createSRSAdapter(memoryAdapter)));
 
     act(() => {
       result.current.recordAnswer('q1', 4);
     });
 
-    const raw = localStorage.getItem('fmq:meta:srs:v1');
+    const raw = memoryAdapter.load(TEST_KEY);
     expect(raw).not.toBeNull();
-
-    const parsed = JSON.parse(raw!);
-    expect(parsed.q1).toBeDefined();
-    expect(parsed.q1.repetitions).toBe(1);
+    expect((raw as Record<string, unknown>).q1).toBeDefined();
+    expect(((raw as Record<string, unknown>).q1 as { repetitions: number }).repetitions).toBe(1);
   });
 
-  it('sollte beim Laden aus localStorage vorhandene Daten übernehmen', () => {
-    localStorage.setItem('fmq:meta:srs:v1', JSON.stringify({
+  it('sollte beim Laden aus Adapter vorhandene Daten übernehmen', () => {
+    memoryAdapter.save(TEST_KEY, {
       q1: { interval: 6, repetitions: 2, efactor: 2.5, nextReview: new Date().toISOString() },
-    }));
+    });
 
-    const { result } = renderHook(() => useSRS());
+    const { result } = renderHook(() => useSRS(createSRSAdapter(memoryAdapter)));
 
     const meta = result.current.getSRSMeta('q1');
     expect(meta).toBeDefined();

--- a/src/test/usePersistentState.test.ts
+++ b/src/test/usePersistentState.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePersistentState } from '@/hooks/usePersistentState';
+import { memoryAdapter } from '@/utils/persistence/memoryAdapter';
+
+describe('usePersistentState', () => {
+  beforeEach(() => {
+    memoryAdapter.clear('demo-key');
+  });
+
+  it('returns default value on first render', () => {
+    const { result } = renderHook(() =>
+      usePersistentState('demo-key', 'default', memoryAdapter),
+    );
+    expect(result.current[0]).toBe('default');
+  });
+
+  it('updates state via setter', () => {
+    const { result } = renderHook(() =>
+      usePersistentState('demo-key', 'default', memoryAdapter),
+    );
+    act(() => {
+      result.current[1]('updated');
+    });
+    expect(result.current[0]).toBe('updated');
+  });
+
+  it('persists to adapter after change', () => {
+    const { result } = renderHook(() =>
+      usePersistentState('demo-key', { count: 0 }, memoryAdapter),
+    );
+    act(() => {
+      result.current[1]({ count: 5 });
+    });
+    const stored = memoryAdapter.load('demo-key');
+    expect(stored).toEqual({ count: 5 });
+  });
+
+  it('loads existing value from adapter on mount', () => {
+    memoryAdapter.save('demo-key', { count: 99 });
+    const { result } = renderHook(() =>
+      usePersistentState('demo-key', { count: 0 }, memoryAdapter),
+    );
+    expect(result.current[0]).toEqual({ count: 99 });
+  });
+
+  it('clears value via clear fn', () => {
+    const { result } = renderHook(() =>
+      usePersistentState('demo-key', 'default', memoryAdapter),
+    );
+    act(() => {
+      result.current[1]('changed');
+    });
+    act(() => {
+      result.current[2]();
+    });
+    expect(result.current[0]).toBe('default');
+    expect(memoryAdapter.load('demo-key')).toBeNull();
+  });
+});

--- a/src/utils/persistence/historyAdapter.ts
+++ b/src/utils/persistence/historyAdapter.ts
@@ -1,0 +1,26 @@
+import type { PersistenceAdapter } from './types';
+import { localStorageAdapter } from './localStorageAdapter';
+// HistoryEntry type used implicitly via mapped entries
+
+const MAX_ENTRIES = 500;
+
+export function createHistoryAdapter(base: PersistenceAdapter = localStorageAdapter): PersistenceAdapter {
+  return {
+    load: (key) => {
+      const raw = base.load(key);
+      if (!Array.isArray(raw)) return [];
+      const migrated = raw.map((entry: unknown) => {
+        const e = entry as Record<string, unknown>;
+        return {
+          ...e,
+          topics: ((e.topics ?? e.bereiche ?? []) as string[]),
+        };
+      });
+      return migrated.slice(0, MAX_ENTRIES);
+    },
+    save: base.save,
+    clear: base.clear,
+  };
+}
+
+export const historyAdapter = createHistoryAdapter();

--- a/src/utils/persistence/index.ts
+++ b/src/utils/persistence/index.ts
@@ -1,3 +1,8 @@
 export type { PersistenceAdapter } from './types';
 export { memoryAdapter } from './memoryAdapter';
 export { localStorageAdapter } from './localStorageAdapter';
+export { createSettingsAdapter, settingsAdapter } from './settingsAdapter';
+export { createHistoryAdapter, historyAdapter } from './historyAdapter';
+export { createSRSAdapter, srsAdapter } from './srsAdapter';
+export { createMetaAdapter, metaAdapter } from './metaAdapter';
+export { createRunAdapter, runAdapter } from './runAdapter';

--- a/src/utils/persistence/index.ts
+++ b/src/utils/persistence/index.ts
@@ -1,0 +1,3 @@
+export type { PersistenceAdapter } from './types';
+export { memoryAdapter } from './memoryAdapter';
+export { localStorageAdapter } from './localStorageAdapter';

--- a/src/utils/persistence/localStorageAdapter.ts
+++ b/src/utils/persistence/localStorageAdapter.ts
@@ -1,0 +1,19 @@
+import type { PersistenceAdapter } from './types';
+
+export const localStorageAdapter: PersistenceAdapter = {
+  load: (key) => {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw) return JSON.parse(raw);
+    } catch {
+      // ignore parse errors
+    }
+    return null;
+  },
+  save: (key, value) => {
+    localStorage.setItem(key, JSON.stringify(value));
+  },
+  clear: (key) => {
+    localStorage.removeItem(key);
+  },
+};

--- a/src/utils/persistence/memoryAdapter.ts
+++ b/src/utils/persistence/memoryAdapter.ts
@@ -1,0 +1,9 @@
+import type { PersistenceAdapter } from './types';
+
+const store = new Map<string, unknown>();
+
+export const memoryAdapter: PersistenceAdapter = {
+  load: (key) => store.get(key) ?? null,
+  save: (key, value) => store.set(key, value),
+  clear: (key) => store.delete(key),
+};

--- a/src/utils/persistence/metaAdapter.ts
+++ b/src/utils/persistence/metaAdapter.ts
@@ -1,0 +1,17 @@
+import type { PersistenceAdapter } from './types';
+import { localStorageAdapter } from './localStorageAdapter';
+import type { MetaProgression } from '@/types/quiz';
+
+export function createMetaAdapter(base: PersistenceAdapter = localStorageAdapter): PersistenceAdapter {
+  return {
+    load: (key) => {
+      const raw = base.load(key);
+      if (typeof raw !== 'object' || raw === null) return null;
+      return { ...(raw as MetaProgression), topics: (raw as MetaProgression).topics ?? {} };
+    },
+    save: base.save,
+    clear: base.clear,
+  };
+}
+
+export const metaAdapter = createMetaAdapter();

--- a/src/utils/persistence/runAdapter.ts
+++ b/src/utils/persistence/runAdapter.ts
@@ -1,0 +1,19 @@
+import type { PersistenceAdapter } from './types';
+import { localStorageAdapter } from './localStorageAdapter';
+import type { QuizRun, GameMode } from '@/types/quiz';
+
+export function createRunAdapter(base: PersistenceAdapter = localStorageAdapter, currentMode?: GameMode): PersistenceAdapter {
+  return {
+    load: base.load,
+    save: (key, value) => {
+      const run = value as QuizRun | null;
+      if (run && run.gameMode && currentMode && run.gameMode !== currentMode) {
+        return;
+      }
+      base.save(key, value);
+    },
+    clear: base.clear,
+  };
+}
+
+export const runAdapter = createRunAdapter();

--- a/src/utils/persistence/settingsAdapter.ts
+++ b/src/utils/persistence/settingsAdapter.ts
@@ -1,0 +1,24 @@
+import type { PersistenceAdapter } from './types';
+import { localStorageAdapter } from './localStorageAdapter';
+import { AppSettingsSchema } from '@/utils/quizLoader';
+import type { AppSettings } from '@/types/quiz';
+
+const DEFAULT_SETTINGS: AppSettings = { gameMode: 'arcade' };
+
+export function createSettingsAdapter(base: PersistenceAdapter = localStorageAdapter): PersistenceAdapter {
+  return {
+    load: (key) => {
+      const raw = base.load(key);
+      const parsed = AppSettingsSchema.safeParse(raw);
+      if (!parsed.success) {
+        console.warn('[Storage] Invalid settings, using defaults:', parsed.error.format());
+        return DEFAULT_SETTINGS;
+      }
+      return parsed.data;
+    },
+    save: base.save,
+    clear: base.clear,
+  };
+}
+
+export const settingsAdapter = createSettingsAdapter();

--- a/src/utils/persistence/srsAdapter.ts
+++ b/src/utils/persistence/srsAdapter.ts
@@ -1,0 +1,27 @@
+import type { PersistenceAdapter } from './types';
+import { localStorageAdapter } from './localStorageAdapter';
+import { SRSMetaSchema } from '@/utils/quizLoader';
+import type { SRSMeta } from '@/types/quiz';
+
+export function createSRSAdapter(base: PersistenceAdapter = localStorageAdapter): PersistenceAdapter {
+  return {
+    load: (key) => {
+      const raw = base.load(key);
+      if (typeof raw !== 'object' || raw === null) return {};
+      const result: Record<string, SRSMeta> = {};
+      for (const [k, value] of Object.entries(raw)) {
+        const parsed = SRSMetaSchema.safeParse(value);
+        if (parsed.success) {
+          result[k] = parsed.data;
+        } else {
+          console.warn('[SRS] Invalid entry for', k, parsed.error.format());
+        }
+      }
+      return result;
+    },
+    save: base.save,
+    clear: base.clear,
+  };
+}
+
+export const srsAdapter = createSRSAdapter();

--- a/src/utils/persistence/types.ts
+++ b/src/utils/persistence/types.ts
@@ -1,0 +1,5 @@
+export interface PersistenceAdapter {
+  load: (key: string) => unknown;
+  save: (key: string, value: unknown) => void;
+  clear: (key: string) => void;
+}


### PR DESCRIPTION
Closes #266

## Summary
Extracts all pure run-state logic from `src/store/quizRun.ts` into deterministic `RunEngine` + `runSelectors` modules. `useQuizRun` shrinks to a thin React wrapper.

## Changes
- `src/engine/runEngine.ts` — pure state transitions: `createRun`, `extendRun`, `answerQuestion`, `selfAssess`, `nextQuestion`, `prevQuestion`, `jumpToQuestion`, `removeTopicFromRun`, `restartRun`, `interruptRun`, `completeRun`, `detectInconsistency`, `purgeMissingQuestions`
- `src/engine/runSelectors.ts` — `selectActiveQuestions`, `selectStatistics`
- `src/store/quizRun.ts` — delegates to `RunEngine`; handles only persistence, cleanup effect, memo, callbacks
- `src/test/runEngine.test.ts` — 37 pure unit tests (no React renderer)

## Verification
- [x] `npm run lint` clean
- [x] `npm run test:run` — 273 tests green (including existing `quizRun.test.ts` without regression)
- [x] `npm run build` clean
